### PR TITLE
Fix review regressions in max_size validation and C++ SDK msg_id handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
   test:
     name: Run Test Suite (ubuntu / py3.11 / node20 / dotnet10)
     runs-on: ubuntu-latest
+    env:
+      SF_DOTNET_TFM: net10.0
 
     permissions:
       contents: read
@@ -164,20 +166,14 @@ jobs:
       - name: Run JS + TS suite
         run: python test_all.py --skip-lang csharp --skip-lang rust
 
-  # .NET SDK matrix: 8 (LTS) and 10 (preview, current dev target).
-  dotnet-matrix:
-    name: dotnet ${{ matrix.dotnet }}
+  # .NET 8 compatibility lane.
+  dotnet-8:
+    name: dotnet 8.0.x
     runs-on: ubuntu-latest
+    env:
+      SF_DOTNET_TFM: net8.0
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - dotnet: "8.0.x"
-            quality: "ga"
-          - dotnet: "10.0.x"
-            quality: "preview"
     steps:
       - uses: actions/checkout@v4
         with: { submodules: true }
@@ -185,16 +181,33 @@ jobs:
         with: { python-version: "3.11" }
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet }}
-          dotnet-quality: ${{ matrix.quality }}
+          dotnet-version: "8.0.x"
+          dotnet-quality: "ga"
       - name: Install Python deps
         run: pip install proto-schema-parser
       - name: Run C# slice
-        # The .NET 8 run will fail if any generated csproj pins net10.0
-        # exclusively — this matrix exists precisely to surface that.
-        # Allowed to fail today via continue-on-error; flip when the gap
-        # documented in test-coverage.md §8 is closed.
-        continue-on-error: ${{ matrix.dotnet == '8.0.x' }}
+        run: python test_all.py --skip-lang rust
+
+  # .NET 10 compatibility lane.
+  dotnet-10:
+    name: dotnet 10.0.x
+    runs-on: ubuntu-latest
+    env:
+      SF_DOTNET_TFM: net10.0
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with: { submodules: true }
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+          dotnet-quality: "preview"
+      - name: Install Python deps
+        run: pip install proto-schema-parser
+      - name: Run C# slice
         run: python test_all.py --skip-lang rust
 
   # Compiler matrix: GCC vs Clang for the C / C++ binaries.

--- a/docs/src/content/docs/extended-features/cpp-sdk.md
+++ b/docs/src/content/docs/extended-features/cpp-sdk.md
@@ -36,19 +36,42 @@ void handle_status(const StatusMessage& msg, uint8_t msgId) {
 }
 
 int main() {
-    // Create SDK with transport and frame parser
-    StructFrame::StructFrameSdkConfig config{
-        .transport = &my_transport,
-        .frameParser = &my_frame_parser,
-    };
-    StructFrame::StructFrameSdk sdk(config);
+    // Create SDK with transport and message-info callback
+    // The profile Config and get_message_info are compile-time template parameters
+    // — all parse/encode calls are fully inlined with zero virtual dispatch.
+    using Sdk = StructFrame::StructFrameSdkT<
+        StructFrame::ProfileStandardConfig,
+        decltype(&get_message_info)>;
+
+    Sdk sdk(&my_transport, &get_message_info);
 
     // Subscribe to messages by message ID
     sdk.subscribe<StatusMessage>(StatusMessage::MSG_ID, handle_status);
 
     // Connect the transport (incoming data is handled via callbacks)
-    sdk.connect();
+    sdk.Connect();
 }
+```
+
+### Convenience Aliases
+
+Profile-specific aliases reduce boilerplate:
+
+```cpp
+// ProfileStandardSdk — most common
+StructFrame::ProfileStandardSdk<decltype(&get_message_info)> sdk(&transport, &get_message_info);
+
+// ProfileSensorSdk — low-bandwidth sensors
+StructFrame::ProfileSensorSdk<decltype(&get_message_info)> sdk(&transport, &get_message_info);
+
+// ProfileIPCSdk — trusted inter-process communication
+StructFrame::ProfileIPCSdk<decltype(&get_message_info)> sdk(&transport, &get_message_info);
+
+// ProfileBulkSdk — large data transfers
+StructFrame::ProfileBulkSdk<decltype(&get_message_info)> sdk(&transport, &get_message_info);
+
+// ProfileNetworkSdk — multi-system networked communication
+StructFrame::ProfileNetworkSdk<decltype(&get_message_info)> sdk(&transport, &get_message_info);
 ```
 
 ## Transports (Full SDK)

--- a/docs/src/content/docs/extended-features/cpp-sdk.md
+++ b/docs/src/content/docs/extended-features/cpp-sdk.md
@@ -36,14 +36,10 @@ void handle_status(const StatusMessage& msg, uint8_t msgId) {
 }
 
 int main() {
-    // Create SDK with transport and message-info callback
-    // The profile Config and get_message_info are compile-time template parameters
-    // — all parse/encode calls are fully inlined with zero virtual dispatch.
-    using Sdk = StructFrame::StructFrameSdkT<
-        StructFrame::ProfileStandardConfig,
-        decltype(&get_message_info)>;
-
-    Sdk sdk(&my_transport, &get_message_info);
+    // Create SDK with transport and message-info callback.
+    // The only template argument is the frame profile config.
+    StructFrame::StructFrameSdkT<StructFrame::ProfileStandardConfig>
+        sdk(&my_transport, &get_message_info);
 
     // Subscribe to messages by message ID
     sdk.subscribe<StatusMessage>(StatusMessage::MSG_ID, handle_status);
@@ -53,25 +49,47 @@ int main() {
 }
 ```
 
-### Convenience Aliases
+## FrameMsgInfo Subscription And Forwarding
 
-Profile-specific aliases reduce boilerplate:
+You can subscribe to every valid parsed frame directly as `FrameMsgInfo`:
 
 ```cpp
-// ProfileStandardSdk — most common
-StructFrame::ProfileStandardSdk<decltype(&get_message_info)> sdk(&transport, &get_message_info);
+StructFrame::StructFrameSdkT<StructFrame::ProfileStandardConfig>
+    sdk(&transport, &get_message_info);
 
-// ProfileSensorSdk — low-bandwidth sensors
-StructFrame::ProfileSensorSdk<decltype(&get_message_info)> sdk(&transport, &get_message_info);
+auto all_frames = sdk.subscribeFrameInfo(
+    [](const StructFrame::FrameMsgInfo& frame) {
+        std::cout << "msg_id=" << frame.msg_id
+                  << " len=" << frame.msg_len << std::endl;
+    });
+```
 
-// ProfileIPCSdk — trusted inter-process communication
-StructFrame::ProfileIPCSdk<decltype(&get_message_info)> sdk(&transport, &get_message_info);
+And you can forward a parsed `FrameMsgInfo` directly through another SDK instance:
 
-// ProfileBulkSdk — large data transfers
-StructFrame::ProfileBulkSdk<decltype(&get_message_info)> sdk(&transport, &get_message_info);
+```cpp
+StructFrame::StructFrameSdkT<StructFrame::ProfileStandardConfig>
+    sdk_a(&transport_a, &get_message_info);
 
-// ProfileNetworkSdk — multi-system networked communication
-StructFrame::ProfileNetworkSdk<decltype(&get_message_info)> sdk(&transport, &get_message_info);
+StructFrame::StructFrameSdkT<StructFrame::ProfileStandardConfig>
+    sdk_b(&transport_b, &get_message_info);
+
+auto forward = sdk_a.subscribeFrameInfo(
+    [&](const StructFrame::FrameMsgInfo& frame) {
+        sdk_b.Send(frame);  // Re-encode and forward through sdk_b transport
+    });
+```
+
+Use the same type for other profiles by changing only the config:
+
+```cpp
+StructFrame::StructFrameSdkT<StructFrame::ProfileSensorConfig>
+    sensor_sdk(&transport, &get_message_info);
+
+StructFrame::StructFrameSdkT<StructFrame::ProfileIPCConfig>
+    ipc_sdk(&transport, &get_message_info);
+
+StructFrame::StructFrameSdkT<StructFrame::ProfileBulkConfig>
+    bulk_sdk(&transport, &get_message_info);
 ```
 
 ## Transports (Full SDK)

--- a/src/struct_frame/__init__.py
+++ b/src/struct_frame/__init__.py
@@ -1,4 +1,4 @@
-from .base import version, NamingStyleC, NamingStyleCpp, camel_to_snake_case, pascal_case, build_enum_leading_comments, build_enum_values, get_discriminator_enum_name, build_discriminator_enum_values
+from .base import version, NamingStyleC, NamingStyleCpp, camel_to_snake_case, pascal_case, build_enum_leading_comments, build_enum_values, get_discriminator_enum_name, build_discriminator_enum_values, normalize_bytes_type
 
 from .c_gen import FileCGen, TestCGen
 from .ts_gen import FileTsGen, TestTsGen
@@ -12,4 +12,4 @@ from .rust_gen import FileRustGen, TestRustGen
 from .generate import main
 
 __all__ = ["main", "FileCGen", "TestCGen", "FileTsGen", "TestTsGen", "FileJsGen", "TestJsGen", "FilePyGen", "TestPyGen", "FileGqlGen", "FileCppGen", "TestCppGen", "FileCSharpGen", "TestCSharpGen", "FileRustGen", "TestRustGen", "version",
-           "NamingStyleC", "NamingStyleCpp", "camel_to_snake_case", "pascal_case", "build_enum_leading_comments", "build_enum_values", "get_discriminator_enum_name", "build_discriminator_enum_values"]
+           "NamingStyleC", "NamingStyleCpp", "camel_to_snake_case", "pascal_case", "build_enum_leading_comments", "build_enum_values", "get_discriminator_enum_name", "build_discriminator_enum_values", "normalize_bytes_type"]

--- a/src/struct_frame/base.py
+++ b/src/struct_frame/base.py
@@ -14,6 +14,12 @@ except Exception:
     version = "0.0.1"
 
 
+def normalize_bytes_type(type_name):
+    """Normalize 'bytes' to 'string' since they share the same wire format
+    (variable-length byte arrays). All generators treat them identically."""
+    return "string" if type_name == "bytes" else type_name
+
+
 class NamingStyle:
     """
     Base class for naming conventions across different languages.

--- a/src/struct_frame/boilerplate/cpp/struct_frame_sdk/network_transports.hpp
+++ b/src/struct_frame/boilerplate/cpp/struct_frame_sdk/network_transports.hpp
@@ -42,7 +42,8 @@ private:
                 if (!error && bytes_transferred > 0) {
                     HandleData(receive_buffer_.data(), bytes_transferred);
                 } else if (error) {
-                    HandleError("UDP receive error: " + error.message());
+                    const std::string err = "UDP receive error: " + error.message();
+                    HandleError(err.c_str());
                 }
                 if (connected_) {
                     startReceive();
@@ -89,7 +90,8 @@ public:
                 io_context_.run();
             });
         } catch (const std::exception& e) {
-            HandleError("UDP connect error: " + std::string(e.what()));
+            const std::string err = "UDP connect error: " + std::string(e.what());
+            HandleError(err.c_str());
             throw;
         }
     }
@@ -115,7 +117,8 @@ public:
         try {
             socket_.send_to(asio::buffer(data, length), remote_endpoint_);
         } catch (const std::exception& e) {
-            HandleError("UDP send error: " + std::string(e.what()));
+            const std::string err = "UDP send error: " + std::string(e.what());
+            HandleError(err.c_str());
         }
     }
 };
@@ -153,7 +156,8 @@ private:
                     if (error == asio::error::eof) {
                         HandleClose();
                     } else {
-                        HandleError("TCP receive error: " + error.message());
+                        const std::string err = "TCP receive error: " + error.message();
+                        HandleError(err.c_str());
                     }
                 }
             }
@@ -191,7 +195,8 @@ public:
                 io_context_.run();
             });
         } catch (const std::exception& e) {
-            HandleError("TCP connect error: " + std::string(e.what()));
+            const std::string err = "TCP connect error: " + std::string(e.what());
+            HandleError(err.c_str());
             throw;
         }
     }
@@ -219,7 +224,8 @@ public:
         try {
             asio::write(socket_, asio::buffer(data, length));
         } catch (const std::exception& e) {
-            HandleError("TCP send error: " + std::string(e.what()));
+            const std::string err = "TCP send error: " + std::string(e.what());
+            HandleError(err.c_str());
         }
     }
 };
@@ -254,7 +260,8 @@ private:
                         startReceive();
                     }
                 } else if (error) {
-                    HandleError("Serial receive error: " + error.message());
+                    const std::string err = "Serial receive error: " + error.message();
+                    HandleError(err.c_str());
                 }
             }
         );
@@ -295,7 +302,8 @@ public:
                 io_context_.run();
             });
         } catch (const std::exception& e) {
-            HandleError("Serial connect error: " + std::string(e.what()));
+            const std::string err = "Serial connect error: " + std::string(e.what());
+            HandleError(err.c_str());
             throw;
         }
     }
@@ -321,7 +329,8 @@ public:
         try {
             asio::write(serial_port_, asio::buffer(data, length));
         } catch (const std::exception& e) {
-            HandleError("Serial send error: " + std::string(e.what()));
+            const std::string err = "Serial send error: " + std::string(e.what());
+            HandleError(err.c_str());
         }
     }
 };

--- a/src/struct_frame/boilerplate/cpp/struct_frame_sdk/struct_frame_sdk.hpp
+++ b/src/struct_frame/boilerplate/cpp/struct_frame_sdk/struct_frame_sdk.hpp
@@ -16,6 +16,8 @@
 #include <type_traits>
 
 namespace structframe {
+struct MessageInfo;
+
 namespace sdk {
 
 // ============================================================================
@@ -90,87 +92,6 @@ struct StructFrameSdkConfig {
 };
 
 // ============================================================================
-// FrameRaw — encode a raw payload into a framed buffer (no MessageBase needed)
-// ============================================================================
-
-/**
- * Encode a raw payload into a framed buffer for a given profile Config.
- * This is the non-templated-message counterpart to FrameEncoderWithCrc::encode()
- * and FrameEncoderMinimal::encode(), used by SendRaw() when no MessageBase
- * object is available.
- *
- * @param msgId      Message ID (low byte; high byte used as pkg_id if Config::has_pkg_id)
- * @param data       Raw payload bytes
- * @param dataLen    Payload length
- * @param output     Output buffer
- * @param outputMaxLen Output buffer capacity
- * @param get_message_info  Callable returning MessageInfo for a given msg_id
- * @return Number of bytes written to output, 0 on failure
- */
-template<typename Config, typename GetMsgInfoFn>
-static size_t FrameRaw(uint8_t msgId, const uint8_t* data, size_t dataLen,
-                       uint8_t* output, size_t outputMaxLen,
-                       GetMsgInfoFn get_message_info) {
-    const auto info = get_message_info(static_cast<uint16_t>(msgId));
-    if (!info.valid) return 0;
-
-    const size_t total = Config::overhead + dataLen;
-    if (outputMaxLen < total || dataLen > Config::max_payload) return 0;
-
-    size_t idx = 0;
-
-    // Start bytes
-    if constexpr (Config::num_start_bytes >= 1)
-        output[idx++] = Config::computed_start_byte1();
-    if constexpr (Config::num_start_bytes >= 2)
-        output[idx++] = Config::computed_start_byte2();
-
-    const size_t crc_start = idx;
-
-    // Optional header fields (defaults: seq=0, sys_id=0, comp_id=0)
-    if constexpr (Config::has_seq)    output[idx++] = 0;
-    if constexpr (Config::has_sys_id) output[idx++] = 0;
-    if constexpr (Config::has_comp_id) output[idx++] = 0;
-
-    // Length field
-    if constexpr (Config::has_length) {
-        if constexpr (Config::length_bytes == 1) {
-            output[idx++] = static_cast<uint8_t>(dataLen & 0xFF);
-        } else {
-            output[idx++] = static_cast<uint8_t>(dataLen & 0xFF);
-            output[idx++] = static_cast<uint8_t>((dataLen >> 8) & 0xFF);
-        }
-    }
-
-    // Message ID (16-bit: high byte is pkg_id when has_pkg_id)
-    if constexpr (Config::has_pkg_id)
-        output[idx++] = static_cast<uint8_t>((msgId >> 8) & 0xFF);
-    output[idx++] = static_cast<uint8_t>(msgId & 0xFF);
-
-    // Payload
-    std::memcpy(output + idx, data, dataLen);
-    idx += dataLen;
-
-    // CRC (extension-aware)
-    if constexpr (Config::has_crc) {
-        size_t crc_len = idx - crc_start;
-        size_t effective_base = crc_len;
-        if constexpr (Config::has_length) {
-            if (info.base_size <= dataLen) {
-                effective_base = (crc_len - dataLen) + info.base_size;
-            }
-        }
-        auto ck = structframe::fletcher_checksum_ext(
-            output + crc_start, effective_base, crc_len,
-            info.magic1, info.magic2);
-        output[idx++] = ck.byte1;
-        output[idx++] = ck.byte2;
-    }
-
-    return idx;
-}
-
-// ============================================================================
 // StructFrameSdkT — main SDK (zero heap, zero virtual dispatch, auto-dispatch)
 // ============================================================================
 
@@ -181,13 +102,11 @@ static size_t FrameRaw(uint8_t msgId, const uint8_t* data, size_t dataLen,
  * Incoming bytes from the transport are automatically parsed and dispatched
  * to all matching subscribers without any explicit user action.
  *
- * The frame profile Config and GetMsgInfoFn are compile-time template
- * parameters, so all parse/encode calls are fully inlined with zero
- * virtual dispatch overhead.
+ * The frame profile Config is a compile-time template parameter, so all
+ * parse/encode calls are fully inlined with zero virtual dispatch overhead.
  *
  * Template parameters (adjust for your platform):
  *   Config           — frame profile configuration (e.g., ProfileStandardConfig)
- *   GetMsgInfoFn     — callable type for MessageInfo lookup (e.g., function pointer)
  *   MaxBuffer        — receive buffer size in bytes                    (default 8192)
  *   MaxSubscriptions — maximum concurrent subscriptions               (default 32)
  *   MaxFrameSize     — maximum outgoing frame size in bytes            (default 512)
@@ -196,18 +115,11 @@ static size_t FrameRaw(uint8_t msgId, const uint8_t* data, size_t dataLen,
  *
  * Usage:
  *   // With function pointer:
- *   StructFrameSdkT<ProfileStandardConfig, decltype(&get_message_info)> sdk(transport, &get_message_info);
- *
- *   // With lambda (deduced type):
- *   auto get_info = [](uint16_t id) { return my_get_message_info(id); };
- *   StructFrameSdkT<ProfileStandardConfig, decltype(get_info)> sdk(transport, get_info);
- *
  *   // Custom sizes for embedded:
- *   StructFrameSdkT<ProfileSensorConfig, decltype(&get_msg_info), 2048, 8, 256, 32> sdk(t, &get_msg_info);
+ *   StructFrameSdkT<ProfileSensorConfig, 2048, 8, 256, 32> sdk(t, &get_msg_info);
  */
 template<
     typename Config,
-    typename GetMsgInfoFn,
     size_t MaxBuffer        = 8192,
     size_t MaxSubscriptions = 32,
     size_t MaxFrameSize     = 512,
@@ -215,6 +127,8 @@ template<
 >
 class StructFrameSdkT : public IStructFrameSdk {
 public:
+    using MessageInfoFn = structframe::MessageInfo (*)(uint16_t);
+
     // Non-copyable, non-movable: internal buffer addresses must remain stable.
     StructFrameSdkT(const StructFrameSdkT&) = delete;
     StructFrameSdkT& operator=(const StructFrameSdkT&) = delete;
@@ -228,9 +142,9 @@ public:
      * @param get_message_info  Callable: MessageInfo(uint16_t msg_id) — returns
      *                          size/magic info for a given message ID
      */
-    StructFrameSdkT(Transport* transport, GetMsgInfoFn get_message_info)
+        StructFrameSdkT(Transport* transport, MessageInfoFn get_message_info)
         : transport_(transport),
-          get_message_info_(static_cast<GetMsgInfoFn&&>(get_message_info)),
+                    get_message_info_(get_message_info),
           buffer_len_(0) {
         for (size_t i = 0; i < MaxSubscriptions; ++i) {
             slots_[i].active = false;
@@ -245,8 +159,8 @@ public:
     /**
      * Construct with a StructFrameSdkConfig (transport only; get_message_info still required).
      */
-    StructFrameSdkT(const StructFrameSdkConfig& config, GetMsgInfoFn get_message_info)
-        : StructFrameSdkT(config.transport, static_cast<GetMsgInfoFn&&>(get_message_info)) {}
+    StructFrameSdkT(const StructFrameSdkConfig& config, MessageInfoFn get_message_info)
+        : StructFrameSdkT(config.transport, get_message_info) {}
 
     ~StructFrameSdkT() {
         for (size_t i = 0; i < MaxSubscriptions; ++i) {
@@ -335,6 +249,44 @@ public:
             [callback](const TMessage& msg, uint8_t id) { callback(msg, id); });
     }
 
+    /**
+     * Subscribe to every valid parsed frame as raw FrameMsgInfo.
+     *
+     * Callback signature: void(const FrameMsgInfo&)
+     */
+    template<typename Callable>
+    SubscriptionHandle subscribeFrameInfo(Callable&& callback) {
+        static_assert(sizeof(Callable) <= MaxCallableSize,
+            "Captured lambda/functor exceeds MaxCallableSize. "
+            "Reduce captures or increase MaxCallableSize template parameter.");
+        static_assert(alignof(Callable) <= alignof(std::max_align_t),
+            "Callable alignment requirement exceeds max_align_t.");
+
+        const size_t idx = FindFreeSlot();
+        if (idx == SubscriptionHandle::INVALID) {
+            return SubscriptionHandle();
+        }
+
+        Slot& slot = slots_[idx];
+        slot.active = true;
+        slot.msg_id = 0;
+        slot.match_all = true;
+
+        new (slot.callable_storage) Callable(static_cast<Callable&&>(callback));
+
+        slot.dispatch_bytes = nullptr;
+        slot.dispatch_typed = nullptr;
+        slot.dispatch_frame_info = [](const FrameMsgInfo& frame, void* ctx) {
+            (*static_cast<Callable*>(ctx))(frame);
+        };
+
+        slot.destroy_fn = [](void* ctx) {
+            static_cast<Callable*>(ctx)->~Callable();
+        };
+
+        return SubscriptionHandle(this, idx);
+    }
+
     // -----------------------------------------------------------------------
     // Notify (direct dispatch, bypasses transport/parser)
     // -----------------------------------------------------------------------
@@ -404,17 +356,30 @@ public:
 
     /**
      * Frame and send a pre-serialized payload through the transport.
-     * Uses FrameRaw() — fully inlined, no virtual dispatch.
+     * Uses an internal raw-frame encoder — fully inlined, no virtual dispatch.
      * Returns true on success.
      */
     bool SendRaw(uint8_t msgId, const uint8_t* data, size_t dataLen) {
         if (transport_ == nullptr) return false;
         uint8_t frame_buf[MaxFrameSize];
-        const size_t framedLen = FrameRaw<Config>(
+        const size_t framedLen = EncodeRawFrame(
             msgId, data, dataLen, frame_buf, MaxFrameSize, get_message_info_);
         if (framedLen == 0) return false;
         transport_->Send(frame_buf, framedLen);
         return true;
+    }
+
+    /**
+     * Forward a parsed FrameMsgInfo through this SDK's transport.
+     *
+     * This is useful when bridging SDK instances: subscribeFrameInfo on one
+     * side, then Send(frame_info) on the other side.
+     */
+    bool Send(const FrameMsgInfo& frame_info) {
+        if (!frame_info.valid || frame_info.msg_data == nullptr) return false;
+        return SendRaw(static_cast<uint8_t>(frame_info.msg_id),
+                       frame_info.msg_data,
+                       frame_info.msg_len);
     }
 
     // IStructFrameSdk
@@ -426,17 +391,20 @@ private:
     struct Slot {
         bool active = false;
         uint8_t msg_id = 0;
+        bool match_all = false;
         void (*dispatch_bytes)(const uint8_t* payload, size_t len,
                                uint8_t msgId, void* ctx) = nullptr;
         void (*dispatch_typed)(const void* msg,
                                uint8_t msgId, void* ctx)  = nullptr;
+        void (*dispatch_frame_info)(const FrameMsgInfo& frame,
+                                    void* ctx)              = nullptr;
         void (*destroy_fn)(void* ctx)                      = nullptr;
         alignas(alignof(std::max_align_t))
             uint8_t callable_storage[MaxCallableSize];
     };
 
     Transport*     transport_;
-    GetMsgInfoFn   get_message_info_;
+    MessageInfoFn  get_message_info_;
     Slot           slots_[MaxSubscriptions];
     uint8_t        buffer_[MaxBuffer];
     size_t         buffer_len_;
@@ -444,6 +412,64 @@ private:
     // -----------------------------------------------------------------------
     // Internal helpers
     // -----------------------------------------------------------------------
+
+    static size_t EncodeRawFrame(uint8_t msgId, const uint8_t* data, size_t dataLen,
+                                 uint8_t* output, size_t outputMaxLen,
+                                 MessageInfoFn get_message_info) {
+        if (get_message_info == nullptr) return 0;
+
+        const auto info = get_message_info(static_cast<uint16_t>(msgId));
+        if (!info.valid) return 0;
+
+        const size_t total = Config::overhead + dataLen;
+        if (outputMaxLen < total || dataLen > Config::max_payload) return 0;
+
+        size_t idx = 0;
+
+        if constexpr (Config::num_start_bytes >= 1)
+            output[idx++] = Config::computed_start_byte1();
+        if constexpr (Config::num_start_bytes >= 2)
+            output[idx++] = Config::computed_start_byte2();
+
+        const size_t crc_start = idx;
+
+        if constexpr (Config::has_seq) output[idx++] = 0;
+        if constexpr (Config::has_sys_id) output[idx++] = 0;
+        if constexpr (Config::has_comp_id) output[idx++] = 0;
+
+        if constexpr (Config::has_length) {
+            if constexpr (Config::length_bytes == 1) {
+                output[idx++] = static_cast<uint8_t>(dataLen & 0xFF);
+            } else {
+                output[idx++] = static_cast<uint8_t>(dataLen & 0xFF);
+                output[idx++] = static_cast<uint8_t>((dataLen >> 8) & 0xFF);
+            }
+        }
+
+        if constexpr (Config::has_pkg_id)
+            output[idx++] = static_cast<uint8_t>((msgId >> 8) & 0xFF);
+        output[idx++] = static_cast<uint8_t>(msgId & 0xFF);
+
+        std::memcpy(output + idx, data, dataLen);
+        idx += dataLen;
+
+        if constexpr (Config::has_crc) {
+            size_t crc_len = idx - crc_start;
+            size_t effective_base = crc_len;
+            if constexpr (Config::has_length) {
+                if (info.base_size <= dataLen) {
+                    effective_base = (crc_len - dataLen) + info.base_size;
+                }
+            }
+            auto ck = structframe::fletcher_checksum_ext(
+                output + crc_start, effective_base, crc_len,
+                info.magic1, info.magic2);
+            output[idx++] = ck.byte1;
+            output[idx++] = ck.byte2;
+        }
+
+        return idx;
+    }
 
     size_t FindFreeSlot() const {
         for (size_t i = 0; i < MaxSubscriptions; ++i) {
@@ -458,8 +484,10 @@ private:
             slot.destroy_fn(slot.callable_storage);
         }
         slot.active        = false;
+        slot.match_all     = false;
         slot.dispatch_bytes = nullptr;
         slot.dispatch_typed = nullptr;
+        slot.dispatch_frame_info = nullptr;
         slot.destroy_fn    = nullptr;
     }
 
@@ -478,8 +506,9 @@ private:
 
             if (!result.valid) break;
 
-            // Auto-dispatch: deserialize payload and notify all matching slots.
-            Dispatch(result.msg_id, result.msg_data, result.msg_len);
+            // Auto-dispatch: notify matching typed subscriptions and raw-frame
+            // subscriptions from the same parsed result.
+            Dispatch(result);
 
             // Advance past the consumed frame.
             // frame_size is populated by all profile parsers; fall back to a
@@ -496,13 +525,20 @@ private:
         }
     }
 
-    void Dispatch(uint16_t msgId, const uint8_t* payload, size_t len) {
-        const auto id8 = static_cast<uint8_t>(msgId);
+    void Dispatch(const FrameMsgInfo& frame) {
+        const auto id8 = static_cast<uint8_t>(frame.msg_id);
         for (size_t i = 0; i < MaxSubscriptions; ++i) {
             Slot& slot = slots_[i];
-            if (slot.active && slot.msg_id == id8 &&
-                slot.dispatch_bytes != nullptr) {
-                slot.dispatch_bytes(payload, len, id8, slot.callable_storage);
+            if (!slot.active) {
+                continue;
+            }
+
+            if (slot.dispatch_frame_info != nullptr && slot.match_all) {
+                slot.dispatch_frame_info(frame, slot.callable_storage);
+            }
+
+            if (!slot.match_all && slot.msg_id == id8 && slot.dispatch_bytes != nullptr) {
+                slot.dispatch_bytes(frame.msg_data, frame.msg_len, id8, slot.callable_storage);
             }
         }
     }
@@ -518,73 +554,6 @@ private:
         static_cast<StructFrameSdkT*>(user_data)->buffer_len_ = 0;
     }
 };
-
-// ============================================================================
-// Convenience aliases
-// ============================================================================
-
-/**
- * ProfileStandardSdk — most common alias for ProfileStandard with default sizing.
- *
- * Usage:
- *   ProfileStandardSdk<decltype(&get_message_info)> sdk(transport, &get_message_info);
- */
-template<typename GetMsgInfoFn,
-    size_t MaxBuffer        = 8192,
-    size_t MaxSubscriptions = 32,
-    size_t MaxFrameSize     = 512,
-    size_t MaxCallableSize  = 64>
-using ProfileStandardSdk = StructFrameSdkT<
-    structframe::ProfileStandardConfig, GetMsgInfoFn,
-    MaxBuffer, MaxSubscriptions, MaxFrameSize, MaxCallableSize>;
-
-/**
- * ProfileSensorSdk — alias for ProfileSensor (Tiny + Minimal).
- */
-template<typename GetMsgInfoFn,
-    size_t MaxBuffer        = 8192,
-    size_t MaxSubscriptions = 32,
-    size_t MaxFrameSize     = 512,
-    size_t MaxCallableSize  = 64>
-using ProfileSensorSdk = StructFrameSdkT<
-    structframe::ProfileSensorConfig, GetMsgInfoFn,
-    MaxBuffer, MaxSubscriptions, MaxFrameSize, MaxCallableSize>;
-
-/**
- * ProfileIPCSdk — alias for ProfileIPC (None + Minimal).
- */
-template<typename GetMsgInfoFn,
-    size_t MaxBuffer        = 8192,
-    size_t MaxSubscriptions = 32,
-    size_t MaxFrameSize     = 512,
-    size_t MaxCallableSize  = 64>
-using ProfileIPCSdk = StructFrameSdkT<
-    structframe::ProfileIPCConfig, GetMsgInfoFn,
-    MaxBuffer, MaxSubscriptions, MaxFrameSize, MaxCallableSize>;
-
-/**
- * ProfileBulkSdk — alias for ProfileBulk (Basic + Extended).
- */
-template<typename GetMsgInfoFn,
-    size_t MaxBuffer        = 8192,
-    size_t MaxSubscriptions = 32,
-    size_t MaxFrameSize     = 512,
-    size_t MaxCallableSize  = 64>
-using ProfileBulkSdk = StructFrameSdkT<
-    structframe::ProfileBulkConfig, GetMsgInfoFn,
-    MaxBuffer, MaxSubscriptions, MaxFrameSize, MaxCallableSize>;
-
-/**
- * ProfileNetworkSdk — alias for ProfileNetwork (Basic + ExtendedMultiSystemStream).
- */
-template<typename GetMsgInfoFn,
-    size_t MaxBuffer        = 8192,
-    size_t MaxSubscriptions = 32,
-    size_t MaxFrameSize     = 512,
-    size_t MaxCallableSize  = 64>
-using ProfileNetworkSdk = StructFrameSdkT<
-    structframe::ProfileNetworkConfig, GetMsgInfoFn,
-    MaxBuffer, MaxSubscriptions, MaxFrameSize, MaxCallableSize>;
 
 } // namespace sdk
 } // namespace structframe

--- a/src/struct_frame/boilerplate/cpp/struct_frame_sdk/struct_frame_sdk.hpp
+++ b/src/struct_frame/boilerplate/cpp/struct_frame_sdk/struct_frame_sdk.hpp
@@ -192,7 +192,7 @@ public:
      * Subscribe to messages of type TMessage identified by msgId.
      *
      * The callback is stored inline inside the SDK — no heap allocation.
-     * Callback signature: void(const TMessage&, uint8_t msgId)
+     * Callback signature: void(const TMessage&, uint16_t msgId)
      *
      * Returns a SubscriptionHandle (RAII). Keep it alive as long as the
      * subscription is needed; destroying it auto-unsubscribes.
@@ -201,7 +201,7 @@ public:
      * static_assert at compile time.
      */
     template<typename TMessage, typename Callable>
-    SubscriptionHandle subscribe(uint8_t msgId, Callable&& callback) {
+    SubscriptionHandle subscribe(uint16_t msgId, Callable&& callback) {
         static_assert(sizeof(Callable) <= MaxCallableSize,
             "Captured lambda/functor exceeds MaxCallableSize. "
             "Reduce captures or increase MaxCallableSize template parameter.");
@@ -221,13 +221,13 @@ public:
         new (slot.callable_storage) Callable(static_cast<Callable&&>(callback));
 
         slot.dispatch_bytes = [](const uint8_t* payload, size_t len,
-                                 uint8_t id, void* ctx) {
+                                 uint16_t id, void* ctx) {
             TMessage msg{};
             msg.deserialize(payload, len);
             (*static_cast<Callable*>(ctx))(msg, id);
         };
 
-        slot.dispatch_typed = [](const void* msg, uint8_t id, void* ctx) {
+        slot.dispatch_typed = [](const void* msg, uint16_t id, void* ctx) {
             (*static_cast<Callable*>(ctx))(
                 *static_cast<const TMessage*>(msg), id);
         };
@@ -243,10 +243,10 @@ public:
      * Subscribe with a plain function pointer (no capture needed).
      */
     template<typename TMessage>
-    SubscriptionHandle subscribe(uint8_t msgId,
-                                 void (*callback)(const TMessage&, uint8_t)) {
+    SubscriptionHandle subscribe(uint16_t msgId,
+                                 void (*callback)(const TMessage&, uint16_t)) {
         return subscribe<TMessage>(msgId,
-            [callback](const TMessage& msg, uint8_t id) { callback(msg, id); });
+            [callback](const TMessage& msg, uint16_t id) { callback(msg, id); });
     }
 
     /**
@@ -296,7 +296,7 @@ public:
      * Useful for injecting messages in tests or for internally generated events.
      */
     template<typename TMessage>
-    void NotifyObservers(uint8_t msgId, const TMessage& message) {
+    void NotifyObservers(uint16_t msgId, const TMessage& message) {
         for (size_t i = 0; i < MaxSubscriptions; ++i) {
             Slot& slot = slots_[i];
             if (slot.active && slot.msg_id == msgId &&
@@ -359,7 +359,7 @@ public:
      * Uses an internal raw-frame encoder — fully inlined, no virtual dispatch.
      * Returns true on success.
      */
-    bool SendRaw(uint8_t msgId, const uint8_t* data, size_t dataLen) {
+    bool SendRaw(uint16_t msgId, const uint8_t* data, size_t dataLen) {
         if (transport_ == nullptr) return false;
         uint8_t frame_buf[MaxFrameSize];
         const size_t framedLen = EncodeRawFrame(
@@ -377,7 +377,7 @@ public:
      */
     bool Send(const FrameMsgInfo& frame_info) {
         if (!frame_info.valid || frame_info.msg_data == nullptr) return false;
-        return SendRaw(static_cast<uint8_t>(frame_info.msg_id),
+        return SendRaw(frame_info.msg_id,
                        frame_info.msg_data,
                        frame_info.msg_len);
     }
@@ -390,12 +390,12 @@ public:
 private:
     struct Slot {
         bool active = false;
-        uint8_t msg_id = 0;
+        uint16_t msg_id = 0;
         bool match_all = false;
         void (*dispatch_bytes)(const uint8_t* payload, size_t len,
-                               uint8_t msgId, void* ctx) = nullptr;
+                               uint16_t msgId, void* ctx) = nullptr;
         void (*dispatch_typed)(const void* msg,
-                               uint8_t msgId, void* ctx)  = nullptr;
+                               uint16_t msgId, void* ctx)  = nullptr;
         void (*dispatch_frame_info)(const FrameMsgInfo& frame,
                                     void* ctx)              = nullptr;
         void (*destroy_fn)(void* ctx)                      = nullptr;
@@ -413,12 +413,12 @@ private:
     // Internal helpers
     // -----------------------------------------------------------------------
 
-    static size_t EncodeRawFrame(uint8_t msgId, const uint8_t* data, size_t dataLen,
+    static size_t EncodeRawFrame(uint16_t msgId, const uint8_t* data, size_t dataLen,
                                  uint8_t* output, size_t outputMaxLen,
                                  MessageInfoFn get_message_info) {
         if (get_message_info == nullptr) return 0;
 
-        const auto info = get_message_info(static_cast<uint16_t>(msgId));
+        const auto info = get_message_info(msgId);
         if (!info.valid) return 0;
 
         const size_t total = Config::overhead + dataLen;
@@ -526,7 +526,7 @@ private:
     }
 
     void Dispatch(const FrameMsgInfo& frame) {
-        const auto id8 = static_cast<uint8_t>(frame.msg_id);
+        const uint16_t msg_id = frame.msg_id;
         for (size_t i = 0; i < MaxSubscriptions; ++i) {
             Slot& slot = slots_[i];
             if (!slot.active) {
@@ -537,8 +537,8 @@ private:
                 slot.dispatch_frame_info(frame, slot.callable_storage);
             }
 
-            if (!slot.match_all && slot.msg_id == id8 && slot.dispatch_bytes != nullptr) {
-                slot.dispatch_bytes(frame.msg_data, frame.msg_len, id8, slot.callable_storage);
+            if (!slot.match_all && slot.msg_id == msg_id && slot.dispatch_bytes != nullptr) {
+                slot.dispatch_bytes(frame.msg_data, frame.msg_len, msg_id, slot.callable_storage);
             }
         }
     }

--- a/src/struct_frame/boilerplate/cpp/struct_frame_sdk/struct_frame_sdk.hpp
+++ b/src/struct_frame/boilerplate/cpp/struct_frame_sdk/struct_frame_sdk.hpp
@@ -1,8 +1,10 @@
 // Struct Frame SDK Client for C++
-// Header-only, zero heap allocation implementation.
+// Header-only, zero heap allocation, zero virtual dispatch implementation.
 //
 // All internal state is preallocated. Incoming bytes are automatically
 // parsed and dispatched to registered subscribers with no dynamic memory use.
+// The frame profile Config and message-info callback are compile-time template
+// parameters — all parse/encode calls are fully inlined with no vtable overhead.
 
 #pragma once
 
@@ -11,35 +13,10 @@
 #include <cstdint>
 #include <cstring>
 #include <new>
+#include <type_traits>
 
 namespace structframe {
 namespace sdk {
-
-// ============================================================================
-// frame_parser interface
-// ============================================================================
-
-/**
- * Frame parser interface implemented by generated frame parsers.
- */
-class frame_parser {
-public:
-    virtual ~frame_parser() = default;
-
-    /**
-     * Parse a buffer and return the first valid frame found.
-     * Returns FrameMsgInfo with valid=true on success; valid=false if no
-     * complete frame is present yet.
-     */
-    virtual structframe::FrameMsgInfo parse(const uint8_t* data, size_t length) = 0;
-
-    /**
-     * Frame (serialize + wrap) a payload for sending.
-     * @return Number of bytes written to output, 0 on failure.
-     */
-    virtual size_t frame(uint8_t msgId, const uint8_t* data, size_t dataLen,
-                         uint8_t* output, size_t outputMaxLen) = 0;
-};
 
 // ============================================================================
 // IStructFrameSdk — non-template base used by SubscriptionHandle
@@ -110,11 +87,91 @@ private:
 
 struct StructFrameSdkConfig {
     Transport* transport = nullptr;
-    frame_parser* parser = nullptr;
 };
 
 // ============================================================================
-// StructFrameSdkT — main SDK (zero heap, auto-dispatch)
+// FrameRaw — encode a raw payload into a framed buffer (no MessageBase needed)
+// ============================================================================
+
+/**
+ * Encode a raw payload into a framed buffer for a given profile Config.
+ * This is the non-templated-message counterpart to FrameEncoderWithCrc::encode()
+ * and FrameEncoderMinimal::encode(), used by SendRaw() when no MessageBase
+ * object is available.
+ *
+ * @param msgId      Message ID (low byte; high byte used as pkg_id if Config::has_pkg_id)
+ * @param data       Raw payload bytes
+ * @param dataLen    Payload length
+ * @param output     Output buffer
+ * @param outputMaxLen Output buffer capacity
+ * @param get_message_info  Callable returning MessageInfo for a given msg_id
+ * @return Number of bytes written to output, 0 on failure
+ */
+template<typename Config, typename GetMsgInfoFn>
+static size_t FrameRaw(uint8_t msgId, const uint8_t* data, size_t dataLen,
+                       uint8_t* output, size_t outputMaxLen,
+                       GetMsgInfoFn get_message_info) {
+    const auto info = get_message_info(static_cast<uint16_t>(msgId));
+    if (!info.valid) return 0;
+
+    const size_t total = Config::overhead + dataLen;
+    if (outputMaxLen < total || dataLen > Config::max_payload) return 0;
+
+    size_t idx = 0;
+
+    // Start bytes
+    if constexpr (Config::num_start_bytes >= 1)
+        output[idx++] = Config::computed_start_byte1();
+    if constexpr (Config::num_start_bytes >= 2)
+        output[idx++] = Config::computed_start_byte2();
+
+    const size_t crc_start = idx;
+
+    // Optional header fields (defaults: seq=0, sys_id=0, comp_id=0)
+    if constexpr (Config::has_seq)    output[idx++] = 0;
+    if constexpr (Config::has_sys_id) output[idx++] = 0;
+    if constexpr (Config::has_comp_id) output[idx++] = 0;
+
+    // Length field
+    if constexpr (Config::has_length) {
+        if constexpr (Config::length_bytes == 1) {
+            output[idx++] = static_cast<uint8_t>(dataLen & 0xFF);
+        } else {
+            output[idx++] = static_cast<uint8_t>(dataLen & 0xFF);
+            output[idx++] = static_cast<uint8_t>((dataLen >> 8) & 0xFF);
+        }
+    }
+
+    // Message ID (16-bit: high byte is pkg_id when has_pkg_id)
+    if constexpr (Config::has_pkg_id)
+        output[idx++] = static_cast<uint8_t>((msgId >> 8) & 0xFF);
+    output[idx++] = static_cast<uint8_t>(msgId & 0xFF);
+
+    // Payload
+    std::memcpy(output + idx, data, dataLen);
+    idx += dataLen;
+
+    // CRC (extension-aware)
+    if constexpr (Config::has_crc) {
+        size_t crc_len = idx - crc_start;
+        size_t effective_base = crc_len;
+        if constexpr (Config::has_length) {
+            if (info.base_size <= dataLen) {
+                effective_base = (crc_len - dataLen) + info.base_size;
+            }
+        }
+        auto ck = structframe::fletcher_checksum_ext(
+            output + crc_start, effective_base, crc_len,
+            info.magic1, info.magic2);
+        output[idx++] = ck.byte1;
+        output[idx++] = ck.byte2;
+    }
+
+    return idx;
+}
+
+// ============================================================================
+// StructFrameSdkT — main SDK (zero heap, zero virtual dispatch, auto-dispatch)
 // ============================================================================
 
 /**
@@ -124,18 +181,33 @@ struct StructFrameSdkConfig {
  * Incoming bytes from the transport are automatically parsed and dispatched
  * to all matching subscribers without any explicit user action.
  *
+ * The frame profile Config and GetMsgInfoFn are compile-time template
+ * parameters, so all parse/encode calls are fully inlined with zero
+ * virtual dispatch overhead.
+ *
  * Template parameters (adjust for your platform):
- *   MaxBuffer        — receive ring buffer size in bytes          (default 8192)
- *   MaxSubscriptions — maximum concurrent subscriptions           (default 32)
- *   MaxFrameSize     — maximum outgoing frame size in bytes       (default 512)
- *   MaxCallableSize  — max size of a captured lambda/functor      (default 64)
+ *   Config           — frame profile configuration (e.g., ProfileStandardConfig)
+ *   GetMsgInfoFn     — callable type for MessageInfo lookup (e.g., function pointer)
+ *   MaxBuffer        — receive buffer size in bytes                    (default 8192)
+ *   MaxSubscriptions — maximum concurrent subscriptions               (default 32)
+ *   MaxFrameSize     — maximum outgoing frame size in bytes            (default 512)
+ *   MaxCallableSize  — max size of a captured lambda/functor           (default 64)
  *                      Exceeding this causes a compile-time error.
  *
  * Usage:
- *   StructFrameSdk sdk(config);          // default sizes
- *   StructFrameSdkT<4096,8,256> sdk(c); // custom sizes
+ *   // With function pointer:
+ *   StructFrameSdkT<ProfileStandardConfig, decltype(&get_message_info)> sdk(transport, &get_message_info);
+ *
+ *   // With lambda (deduced type):
+ *   auto get_info = [](uint16_t id) { return my_get_message_info(id); };
+ *   StructFrameSdkT<ProfileStandardConfig, decltype(get_info)> sdk(transport, get_info);
+ *
+ *   // Custom sizes for embedded:
+ *   StructFrameSdkT<ProfileSensorConfig, decltype(&get_msg_info), 2048, 8, 256, 32> sdk(t, &get_msg_info);
  */
 template<
+    typename Config,
+    typename GetMsgInfoFn,
     size_t MaxBuffer        = 8192,
     size_t MaxSubscriptions = 32,
     size_t MaxFrameSize     = 512,
@@ -149,9 +221,16 @@ public:
     StructFrameSdkT(StructFrameSdkT&&) = delete;
     StructFrameSdkT& operator=(StructFrameSdkT&&) = delete;
 
-    explicit StructFrameSdkT(const StructFrameSdkConfig& config)
-        : transport_(config.transport),
-          parser_(config.parser),
+    /**
+     * Construct the SDK with a transport and message-info callback.
+     *
+     * @param transport  Transport for sending/receiving data (may be nullptr for feed-only use)
+     * @param get_message_info  Callable: MessageInfo(uint16_t msg_id) — returns
+     *                          size/magic info for a given message ID
+     */
+    StructFrameSdkT(Transport* transport, GetMsgInfoFn get_message_info)
+        : transport_(transport),
+          get_message_info_(static_cast<GetMsgInfoFn&&>(get_message_info)),
           buffer_len_(0) {
         for (size_t i = 0; i < MaxSubscriptions; ++i) {
             slots_[i].active = false;
@@ -162,6 +241,12 @@ public:
             transport_->OnClose(&StructFrameSdkT::CloseCallbackWrapper, this);
         }
     }
+
+    /**
+     * Construct with a StructFrameSdkConfig (transport only; get_message_info still required).
+     */
+    StructFrameSdkT(const StructFrameSdkConfig& config, GetMsgInfoFn get_message_info)
+        : StructFrameSdkT(config.transport, static_cast<GetMsgInfoFn&&>(get_message_info)) {}
 
     ~StructFrameSdkT() {
         for (size_t i = 0; i < MaxSubscriptions; ++i) {
@@ -220,9 +305,6 @@ public:
 
         // Placement-construct the callable into the inline storage.
         new (slot.callable_storage) Callable(static_cast<Callable&&>(callback));
-
-        // Non-capturing lambdas that reference TMessage/Callable as template
-        // parameters are implicitly convertible to plain function pointers.
 
         slot.dispatch_bytes = [](const uint8_t* payload, size_t len,
                                  uint8_t id, void* ctx) {
@@ -297,25 +379,39 @@ public:
 
     /**
      * Serialize and send a typed message through the transport.
+     * Uses FrameEncoderWithCrc or FrameEncoderMinimal based on the profile
+     * — fully inlined, no virtual dispatch.
      * Returns true if the frame was successfully handed to the transport.
      */
     template<typename TMessage>
     bool Send(const TMessage& message) {
-        uint8_t payload[TMessage::MAX_SIZE];
-        message.serialize(payload);
-        return SendRaw(static_cast<uint8_t>(TMessage::MSG_ID), payload,
-                       TMessage::MAX_SIZE);
+        if (transport_ == nullptr) return false;
+        uint8_t frame_buf[MaxFrameSize];
+        size_t framedLen;
+
+        if constexpr (Config::has_length || Config::has_crc) {
+            framedLen = structframe::FrameEncoderWithCrc<Config>::encode(
+                frame_buf, MaxFrameSize, message);
+        } else {
+            framedLen = structframe::FrameEncoderMinimal<Config>::encode(
+                frame_buf, MaxFrameSize, message);
+        }
+
+        if (framedLen == 0) return false;
+        transport_->Send(frame_buf, framedLen);
+        return true;
     }
 
     /**
      * Frame and send a pre-serialized payload through the transport.
+     * Uses FrameRaw() — fully inlined, no virtual dispatch.
      * Returns true on success.
      */
     bool SendRaw(uint8_t msgId, const uint8_t* data, size_t dataLen) {
-        if (parser_ == nullptr || transport_ == nullptr) return false;
+        if (transport_ == nullptr) return false;
         uint8_t frame_buf[MaxFrameSize];
-        const size_t framedLen = parser_->frame(msgId, data, dataLen,
-                                                frame_buf, MaxFrameSize);
+        const size_t framedLen = FrameRaw<Config>(
+            msgId, data, dataLen, frame_buf, MaxFrameSize, get_message_info_);
         if (framedLen == 0) return false;
         transport_->Send(frame_buf, framedLen);
         return true;
@@ -339,11 +435,11 @@ private:
             uint8_t callable_storage[MaxCallableSize];
     };
 
-    Transport*   transport_;
-    frame_parser* parser_;
-    Slot         slots_[MaxSubscriptions];
-    uint8_t      buffer_[MaxBuffer];
-    size_t       buffer_len_;
+    Transport*     transport_;
+    GetMsgInfoFn   get_message_info_;
+    Slot           slots_[MaxSubscriptions];
+    uint8_t        buffer_[MaxBuffer];
+    size_t         buffer_len_;
 
     // -----------------------------------------------------------------------
     // Internal helpers
@@ -369,7 +465,17 @@ private:
 
     void ParseBuffer() {
         while (buffer_len_ > 0) {
-            const FrameMsgInfo result = parser_->parse(buffer_, buffer_len_);
+            FrameMsgInfo result;
+
+            // Compile-time dispatch: no virtual call, fully inlined.
+            if constexpr (Config::has_length || Config::has_crc) {
+                result = structframe::BufferParserWithCrc<Config>::parse(
+                    buffer_, buffer_len_, get_message_info_);
+            } else {
+                result = structframe::BufferParserMinimal<Config>::parse(
+                    buffer_, buffer_len_, get_message_info_);
+            }
+
             if (!result.valid) break;
 
             // Auto-dispatch: deserialize payload and notify all matching slots.
@@ -413,9 +519,72 @@ private:
     }
 };
 
-// Convenience alias with default sizing — covers the common case and keeps
-// existing code (StructFrameSdk sdk(config)) compiling unchanged.
-using StructFrameSdk = StructFrameSdkT<>;
+// ============================================================================
+// Convenience aliases
+// ============================================================================
+
+/**
+ * ProfileStandardSdk — most common alias for ProfileStandard with default sizing.
+ *
+ * Usage:
+ *   ProfileStandardSdk<decltype(&get_message_info)> sdk(transport, &get_message_info);
+ */
+template<typename GetMsgInfoFn,
+    size_t MaxBuffer        = 8192,
+    size_t MaxSubscriptions = 32,
+    size_t MaxFrameSize     = 512,
+    size_t MaxCallableSize  = 64>
+using ProfileStandardSdk = StructFrameSdkT<
+    structframe::ProfileStandardConfig, GetMsgInfoFn,
+    MaxBuffer, MaxSubscriptions, MaxFrameSize, MaxCallableSize>;
+
+/**
+ * ProfileSensorSdk — alias for ProfileSensor (Tiny + Minimal).
+ */
+template<typename GetMsgInfoFn,
+    size_t MaxBuffer        = 8192,
+    size_t MaxSubscriptions = 32,
+    size_t MaxFrameSize     = 512,
+    size_t MaxCallableSize  = 64>
+using ProfileSensorSdk = StructFrameSdkT<
+    structframe::ProfileSensorConfig, GetMsgInfoFn,
+    MaxBuffer, MaxSubscriptions, MaxFrameSize, MaxCallableSize>;
+
+/**
+ * ProfileIPCSdk — alias for ProfileIPC (None + Minimal).
+ */
+template<typename GetMsgInfoFn,
+    size_t MaxBuffer        = 8192,
+    size_t MaxSubscriptions = 32,
+    size_t MaxFrameSize     = 512,
+    size_t MaxCallableSize  = 64>
+using ProfileIPCSdk = StructFrameSdkT<
+    structframe::ProfileIPCConfig, GetMsgInfoFn,
+    MaxBuffer, MaxSubscriptions, MaxFrameSize, MaxCallableSize>;
+
+/**
+ * ProfileBulkSdk — alias for ProfileBulk (Basic + Extended).
+ */
+template<typename GetMsgInfoFn,
+    size_t MaxBuffer        = 8192,
+    size_t MaxSubscriptions = 32,
+    size_t MaxFrameSize     = 512,
+    size_t MaxCallableSize  = 64>
+using ProfileBulkSdk = StructFrameSdkT<
+    structframe::ProfileBulkConfig, GetMsgInfoFn,
+    MaxBuffer, MaxSubscriptions, MaxFrameSize, MaxCallableSize>;
+
+/**
+ * ProfileNetworkSdk — alias for ProfileNetwork (Basic + ExtendedMultiSystemStream).
+ */
+template<typename GetMsgInfoFn,
+    size_t MaxBuffer        = 8192,
+    size_t MaxSubscriptions = 32,
+    size_t MaxFrameSize     = 512,
+    size_t MaxCallableSize  = 64>
+using ProfileNetworkSdk = StructFrameSdkT<
+    structframe::ProfileNetworkConfig, GetMsgInfoFn,
+    MaxBuffer, MaxSubscriptions, MaxFrameSize, MaxCallableSize>;
 
 } // namespace sdk
 } // namespace structframe

--- a/src/struct_frame/boilerplate/cpp/struct_frame_sdk/struct_frame_sdk.hpp
+++ b/src/struct_frame/boilerplate/cpp/struct_frame_sdk/struct_frame_sdk.hpp
@@ -1,323 +1,421 @@
 // Struct Frame SDK Client for C++
-// Header-only implementation
+// Header-only, zero heap allocation implementation.
+//
+// All internal state is preallocated. Incoming bytes are automatically
+// parsed and dispatched to registered subscribers with no dynamic memory use.
 
 #pragma once
 
 #include "transport.hpp"
-#include "observer.hpp"
-#include <map>
-#include <vector>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <new>
 
 namespace structframe {
 namespace sdk {
 
+// ============================================================================
+// frame_parser interface
+// ============================================================================
+
 /**
- * Frame parser interface - must be implemented by generated frame parsers
+ * Frame parser interface implemented by generated frame parsers.
  */
 class frame_parser {
 public:
     virtual ~frame_parser() = default;
 
     /**
-     * Parse incoming data and extract message
-     * Returns frame message info with valid flag
+     * Parse a buffer and return the first valid frame found.
+     * Returns FrameMsgInfo with valid=true on success; valid=false if no
+     * complete frame is present yet.
      */
     virtual structframe::FrameMsgInfo parse(const uint8_t* data, size_t length) = 0;
 
     /**
-     * Frame a message for sending
-     * @param msgId Message ID
-     * @param data Message payload
-     * @param dataLen Payload length
-     * @param output Output buffer for framed message
-     * @param outputMaxLen Maximum output buffer size
-     * @return Actual framed message length
+     * Frame (serialize + wrap) a payload for sending.
+     * @return Number of bytes written to output, 0 on failure.
      */
     virtual size_t frame(uint8_t msgId, const uint8_t* data, size_t dataLen,
-                        uint8_t* output, size_t outputMaxLen) = 0;
+                         uint8_t* output, size_t outputMaxLen) = 0;
 };
 
-/**
- * Message codec interface - deserializes raw bytes into message objects
- */
-template<typename TMessage>
-class MessageCodec {
+// ============================================================================
+// IStructFrameSdk — non-template base used by SubscriptionHandle
+// ============================================================================
+
+class IStructFrameSdk {
 public:
-    virtual ~MessageCodec() = default;
-
-    /**
-     * Get message ID for this codec
-     */
-    virtual uint8_t GetMsgId() const = 0;
-
-    /**
-     * Deserialize bytes into message object
-     */
-    virtual bool deserialize(const uint8_t* data, size_t length, TMessage& message) = 0;
+    virtual ~IStructFrameSdk() = default;
+    virtual void FreeSlot(size_t idx) = 0;
 };
 
-/**
- * Struct Frame SDK Configuration
- */
-struct StructFrameSdkConfig {
-    Transport* transport;
-    frame_parser* parser;
-    bool debug = false;
-    size_t max_buffer_size = 8192;
-};
+// ============================================================================
+// SubscriptionHandle — RAII, move-only subscription token
+// ============================================================================
 
 /**
- * Main SDK Client
+ * Returned by StructFrameSdk::subscribe(). Auto-unsubscribes on destruction.
+ * Must be kept alive (as a class member or named local) for as long as the
+ * subscription is needed.
  */
-class StructFrameSdk {
+class SubscriptionHandle {
+public:
+    static constexpr size_t INVALID = ~size_t{0};
+
+    SubscriptionHandle() : sdk_(nullptr), slot_idx_(INVALID) {}
+    SubscriptionHandle(IStructFrameSdk* sdk, size_t idx) : sdk_(sdk), slot_idx_(idx) {}
+
+    ~SubscriptionHandle() { Unsubscribe(); }
+
+    SubscriptionHandle(SubscriptionHandle&& other) noexcept
+        : sdk_(other.sdk_), slot_idx_(other.slot_idx_) {
+        other.sdk_ = nullptr;
+        other.slot_idx_ = INVALID;
+    }
+
+    SubscriptionHandle& operator=(SubscriptionHandle&& other) noexcept {
+        if (this != &other) {
+            Unsubscribe();
+            sdk_ = other.sdk_;
+            slot_idx_ = other.slot_idx_;
+            other.sdk_ = nullptr;
+            other.slot_idx_ = INVALID;
+        }
+        return *this;
+    }
+
+    SubscriptionHandle(const SubscriptionHandle&) = delete;
+    SubscriptionHandle& operator=(const SubscriptionHandle&) = delete;
+
+    void Unsubscribe() {
+        if (sdk_ != nullptr && slot_idx_ != INVALID) {
+            sdk_->FreeSlot(slot_idx_);
+            sdk_ = nullptr;
+            slot_idx_ = INVALID;
+        }
+    }
+
+    bool IsActive() const { return sdk_ != nullptr && slot_idx_ != INVALID; }
+
 private:
-    Transport* transport_;
-    frame_parser* frame_parser_;
-    bool debug_;
-    std::vector<uint8_t> buffer_;
-    size_t max_buffer_size_;
+    IStructFrameSdk* sdk_;
+    size_t slot_idx_;
+};
 
-    // Type-erased observable map for different message types
-    std::map<uint8_t, void*> observables_;
+// ============================================================================
+// StructFrameSdkConfig
+// ============================================================================
 
-    void HandleIncomingData(const uint8_t* data, size_t length) {
-        // Append to buffer
-        if (buffer_.size() + length > max_buffer_size_) {
-            log("Buffer overflow, clearing buffer");
-            buffer_.clear();
+struct StructFrameSdkConfig {
+    Transport* transport = nullptr;
+    frame_parser* parser = nullptr;
+};
+
+// ============================================================================
+// StructFrameSdkT — main SDK (zero heap, auto-dispatch)
+// ============================================================================
+
+/**
+ * Struct Frame SDK client.
+ *
+ * All internal state is stack/member allocated — no dynamic memory.
+ * Incoming bytes from the transport are automatically parsed and dispatched
+ * to all matching subscribers without any explicit user action.
+ *
+ * Template parameters (adjust for your platform):
+ *   MaxBuffer        — receive ring buffer size in bytes          (default 8192)
+ *   MaxSubscriptions — maximum concurrent subscriptions           (default 32)
+ *   MaxFrameSize     — maximum outgoing frame size in bytes       (default 512)
+ *   MaxCallableSize  — max size of a captured lambda/functor      (default 64)
+ *                      Exceeding this causes a compile-time error.
+ *
+ * Usage:
+ *   StructFrameSdk sdk(config);          // default sizes
+ *   StructFrameSdkT<4096,8,256> sdk(c); // custom sizes
+ */
+template<
+    size_t MaxBuffer        = 8192,
+    size_t MaxSubscriptions = 32,
+    size_t MaxFrameSize     = 512,
+    size_t MaxCallableSize  = 64
+>
+class StructFrameSdkT : public IStructFrameSdk {
+public:
+    // Non-copyable, non-movable: internal buffer addresses must remain stable.
+    StructFrameSdkT(const StructFrameSdkT&) = delete;
+    StructFrameSdkT& operator=(const StructFrameSdkT&) = delete;
+    StructFrameSdkT(StructFrameSdkT&&) = delete;
+    StructFrameSdkT& operator=(StructFrameSdkT&&) = delete;
+
+    explicit StructFrameSdkT(const StructFrameSdkConfig& config)
+        : transport_(config.transport),
+          parser_(config.parser),
+          buffer_len_(0) {
+        for (size_t i = 0; i < MaxSubscriptions; ++i) {
+            slots_[i].active = false;
+        }
+        if (transport_ != nullptr) {
+            transport_->OnData(&StructFrameSdkT::DataCallbackWrapper, this);
+            transport_->OnError(&StructFrameSdkT::ErrorCallbackWrapper, this);
+            transport_->OnClose(&StructFrameSdkT::CloseCallbackWrapper, this);
+        }
+    }
+
+    ~StructFrameSdkT() {
+        for (size_t i = 0; i < MaxSubscriptions; ++i) {
+            DestroySlot(i);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Transport lifecycle
+    // -----------------------------------------------------------------------
+
+    void Connect() {
+        if (transport_ != nullptr) transport_->Connect();
+    }
+
+    void Disconnect() {
+        if (transport_ != nullptr) transport_->Disconnect();
+    }
+
+    bool IsConnected() const {
+        return transport_ != nullptr && transport_->IsConnected();
+    }
+
+    // -----------------------------------------------------------------------
+    // Subscribe
+    // -----------------------------------------------------------------------
+
+    /**
+     * Subscribe to messages of type TMessage identified by msgId.
+     *
+     * The callback is stored inline inside the SDK — no heap allocation.
+     * Callback signature: void(const TMessage&, uint8_t msgId)
+     *
+     * Returns a SubscriptionHandle (RAII). Keep it alive as long as the
+     * subscription is needed; destroying it auto-unsubscribes.
+     *
+     * Lambdas that capture more than MaxCallableSize bytes trigger a
+     * static_assert at compile time.
+     */
+    template<typename TMessage, typename Callable>
+    SubscriptionHandle subscribe(uint8_t msgId, Callable&& callback) {
+        static_assert(sizeof(Callable) <= MaxCallableSize,
+            "Captured lambda/functor exceeds MaxCallableSize. "
+            "Reduce captures or increase MaxCallableSize template parameter.");
+        static_assert(alignof(Callable) <= alignof(std::max_align_t),
+            "Callable alignment requirement exceeds max_align_t.");
+
+        const size_t idx = FindFreeSlot();
+        if (idx == SubscriptionHandle::INVALID) {
+            return SubscriptionHandle(); // all slots full
         }
 
-        buffer_.insert(buffer_.end(), data, data + length);
+        Slot& slot = slots_[idx];
+        slot.active  = true;
+        slot.msg_id  = msgId;
 
-        // Try to parse messages from buffer
+        // Placement-construct the callable into the inline storage.
+        new (slot.callable_storage) Callable(static_cast<Callable&&>(callback));
+
+        // Non-capturing lambdas that reference TMessage/Callable as template
+        // parameters are implicitly convertible to plain function pointers.
+
+        slot.dispatch_bytes = [](const uint8_t* payload, size_t len,
+                                 uint8_t id, void* ctx) {
+            TMessage msg{};
+            msg.deserialize(payload, len);
+            (*static_cast<Callable*>(ctx))(msg, id);
+        };
+
+        slot.dispatch_typed = [](const void* msg, uint8_t id, void* ctx) {
+            (*static_cast<Callable*>(ctx))(
+                *static_cast<const TMessage*>(msg), id);
+        };
+
+        slot.destroy_fn = [](void* ctx) {
+            static_cast<Callable*>(ctx)->~Callable();
+        };
+
+        return SubscriptionHandle(this, idx);
+    }
+
+    /**
+     * Subscribe with a plain function pointer (no capture needed).
+     */
+    template<typename TMessage>
+    SubscriptionHandle subscribe(uint8_t msgId,
+                                 void (*callback)(const TMessage&, uint8_t)) {
+        return subscribe<TMessage>(msgId,
+            [callback](const TMessage& msg, uint8_t id) { callback(msg, id); });
+    }
+
+    // -----------------------------------------------------------------------
+    // Notify (direct dispatch, bypasses transport/parser)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Directly dispatch a pre-deserialized message to all matching subscribers.
+     * Useful for injecting messages in tests or for internally generated events.
+     */
+    template<typename TMessage>
+    void NotifyObservers(uint8_t msgId, const TMessage& message) {
+        for (size_t i = 0; i < MaxSubscriptions; ++i) {
+            Slot& slot = slots_[i];
+            if (slot.active && slot.msg_id == msgId &&
+                slot.dispatch_typed != nullptr) {
+                slot.dispatch_typed(&message, msgId, slot.callable_storage);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Feed (explicit parse trigger)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Feed raw bytes into the receive buffer and parse/dispatch any complete
+     * frames. Called automatically via the transport data callback; can also
+     * be called directly for testing or non-transport use.
+     */
+    void Feed(const uint8_t* data, size_t length) {
+        if (data == nullptr || length == 0) return;
+        if (buffer_len_ + length > MaxBuffer) {
+            buffer_len_ = 0; // overflow: drop buffered data
+        }
+        std::memcpy(buffer_ + buffer_len_, data, length);
+        buffer_len_ += length;
         ParseBuffer();
     }
 
-    void ParseBuffer() {
-        while (!buffer_.empty()) {
-            auto result = frame_parser_->parse(buffer_.data(), buffer_.size());
-
-            if (!result.valid) {
-                // No valid frame found
-                break;
-            }
-
-            // Valid message found
-            log("Received message ID " + std::to_string(result.msg_id) +
-                ", " + std::to_string(result.msg_len) + " bytes");
-
-            // Notify observers (user must call NotifyObservers with proper type)
-            // This is handled by the typed NotifyObservers method
-
-            // Remove parsed data from buffer
-            size_t frameSize = CalculateFrameSize(result);
-            if (frameSize == 0 || frameSize > buffer_.size()) {
-                // Safety guard: if CalculateFrameSize returns more than the buffer
-                // holds (e.g. conservative estimate exceeded actual data), consume
-                // the whole buffer to avoid an infinite loop.
-                buffer_.clear();
-                break;
-            }
-            buffer_.erase(buffer_.begin(), buffer_.begin() + frameSize);
-        }
-    }
-
-    size_t CalculateFrameSize(const structframe::FrameMsgInfo& result) const {
-        // Prefer the exact total frame size reported by the parser when available.
-        if (result.frame_size > 0) {
-            return result.frame_size;
-        }
-        // Fallback: conservative estimate of 10 bytes overhead to handle all
-        // frame formats when the parser does not populate frame_size.
-        // TODO: Query frame parser for exact overhead to avoid buffering issues
-        return result.msg_len + 10;
-    }
-
-    void HandleError(const std::string& error) {
-        log("Transport error: ");
-        log(error);
-    }
-
-    void HandleClose() {
-        log("Transport closed");
-        buffer_.clear();
-    }
-
-    void log(const std::string& message) {
-        if (debug_) {
-            // In a real implementation, this would use platform-specific logging
-            // printf("[StructFrameSdk] %s\n", message.c_str());
-        }
-    }
-
-    void log(const char* message) {
-        if (debug_) {
-            // In a real implementation, this would use platform-specific logging
-            // printf("[StructFrameSdk] %s\n", message);
-        }
-    }
-
-    // Static callback wrappers for transport
-    static void DataCallbackWrapper(const uint8_t* data, size_t length, void* user_data) {
-        auto* self = static_cast<StructFrameSdk*>(user_data);
-        self->HandleIncomingData(data, length);
-    }
-
-    static void ErrorCallbackWrapper(const char* error, void* user_data) {
-        auto* self = static_cast<StructFrameSdk*>(user_data);
-        self->HandleError(error);
-    }
-
-    static void CloseCallbackWrapper(void* user_data) {
-        auto* self = static_cast<StructFrameSdk*>(user_data);
-        self->HandleClose();
-    }
-
-public:
-    StructFrameSdk(const StructFrameSdkConfig& config)
-        : transport_(config.transport),
-          frame_parser_(config.parser),
-          debug_(config.debug),
-          max_buffer_size_(config.max_buffer_size) {
-
-        buffer_.reserve(max_buffer_size_);
-
-        // Set up transport callbacks using static wrappers
-        transport_->OnData(DataCallbackWrapper, this);
-        transport_->OnError(ErrorCallbackWrapper, this);
-        transport_->OnClose(CloseCallbackWrapper, this);
-    }
-
-    ~StructFrameSdk() {
-        // Clean up observables
-        for (auto& pair : observables_) {
-            // Type-erased, would need proper cleanup in real implementation
-        }
-    }
+    // -----------------------------------------------------------------------
+    // Send
+    // -----------------------------------------------------------------------
 
     /**
-     * Connect to the transport
-     */
-    void Connect() {
-        transport_->Connect();
-        log("Connected");
-    }
-
-    /**
-     * Disconnect from the transport
-     */
-    void Disconnect() {
-        transport_->Disconnect();
-        log("Disconnected");
-    }
-
-    /**
-     * Get or create observable for a specific message type
-     * @tparam TMessage The message type
-     * @tparam MaxObservers Maximum number of observers (default 16)
-     * @param msgId The message ID
-     */
-    template<typename TMessage, size_t MaxObservers = 16>
-    Observable<TMessage, MaxObservers>* GetObservable(uint8_t msgId) {
-        auto it = observables_.find(msgId);
-        if (it == observables_.end()) {
-            auto* observable = new Observable<TMessage, MaxObservers>();
-            observables_[msgId] = static_cast<void*>(observable);
-            return observable;
-        }
-        return static_cast<Observable<TMessage, MaxObservers>*>(it->second);
-    }
-
-    /**
-     * Subscribe to messages with a specific message ID
-     * @tparam TMessage The message type
-     * @tparam MaxObservers Maximum number of observers (default 16)
-     * @param msgId The message ID
-     * @param observer The observer to subscribe
-     * @return Subscription handle (RAII)
-     */
-    template<typename TMessage, size_t MaxObservers = 16>
-    Subscription<TMessage, MaxObservers> subscribe(uint8_t msgId, IObserver<TMessage>* observer) {
-        auto* observable = GetObservable<TMessage, MaxObservers>(msgId);
-        observable->subscribe(observer);
-        log("Subscribed to message ID " + std::to_string(msgId));
-        return Subscription<TMessage, MaxObservers>(observable, observer);
-    }
-
-    /**
-     * Subscribe with a callable (lambda, functor, etc.)
-     * @tparam TMessage The message type
-     * @tparam Callable The callable type
-     * @tparam MaxObservers Maximum number of observers (default 16)
-     * @param msgId The message ID
-     * @param callback Callable to invoke when message is received
-     * @return Subscription handle (RAII) - keep alive as long as subscription is needed
-     */
-    template<typename TMessage, typename Callable, size_t MaxObservers = 16>
-    Subscription<TMessage, MaxObservers> subscribe(uint8_t msgId, Callable callback) {
-        auto* observer = new CallableObserver<TMessage, Callable>(callback);
-        auto* observable = GetObservable<TMessage, MaxObservers>(msgId);
-        observable->subscribe(observer);
-        log("Subscribed to message ID " + std::to_string(msgId));
-        return Subscription<TMessage, MaxObservers>(observable, observer);
-    }
-
-    /**
-     * Notify observers of a parsed message (internal use)
-     * @tparam TMessage The message type
-     * @tparam MaxObservers Maximum number of observers (default 16)
-     * @param msgId The message ID
-     * @param message The parsed message
-     */
-    template<typename TMessage, size_t MaxObservers = 16>
-    void NotifyObservers(uint8_t msgId, const TMessage& message) {
-        auto it = observables_.find(msgId);
-        if (it != observables_.end()) {
-            auto* observable = static_cast<Observable<TMessage, MaxObservers>*>(it->second);
-            observable->notify(message, msgId);
-        }
-    }
-
-    /**
-     * Send a raw message (already serialized)
-     * @param msgId Message ID
-     * @param data Message payload
-     * @param dataLen Payload length
-     */
-    void SendRaw(uint8_t msgId, const uint8_t* data, size_t dataLen) {
-        // Frame the message
-        std::vector<uint8_t> framedData(dataLen + 20);  // Extra space for framing
-        size_t framedLen = frame_parser_->frame(msgId, data, dataLen,
-                                              framedData.data(), framedData.size());
-
-        transport_->Send(framedData.data(), framedLen);
-        log("Sent message ID " + std::to_string(msgId) + ", " +
-            std::to_string(dataLen) + " bytes");
-    }
-
-    /**
-     * Send a message object (requires pack() method and msg_id member)
-     * @tparam TMessage Message type
-     * @param message The message to send
+     * Serialize and send a typed message through the transport.
+     * Returns true if the frame was successfully handed to the transport.
      */
     template<typename TMessage>
-    void Send(const TMessage& message) {
-        // Assuming message has pack method and msg_id member
-        std::vector<uint8_t> packed(message.msg_size);
-        // User would call message.pack(packed.data()) or similar
-        // This is placeholder - actual implementation depends on generated code
-        SendRaw(message.msg_id, packed.data(), packed.size());
+    bool Send(const TMessage& message) {
+        uint8_t payload[TMessage::MAX_SIZE];
+        message.serialize(payload);
+        return SendRaw(static_cast<uint8_t>(TMessage::MSG_ID), payload,
+                       TMessage::MAX_SIZE);
     }
 
     /**
-     * Check if connected
+     * Frame and send a pre-serialized payload through the transport.
+     * Returns true on success.
      */
-    bool IsConnected() const {
-        return transport_->IsConnected();
+    bool SendRaw(uint8_t msgId, const uint8_t* data, size_t dataLen) {
+        if (parser_ == nullptr || transport_ == nullptr) return false;
+        uint8_t frame_buf[MaxFrameSize];
+        const size_t framedLen = parser_->frame(msgId, data, dataLen,
+                                                frame_buf, MaxFrameSize);
+        if (framedLen == 0) return false;
+        transport_->Send(frame_buf, framedLen);
+        return true;
+    }
+
+    // IStructFrameSdk
+    void FreeSlot(size_t idx) override {
+        if (idx < MaxSubscriptions) DestroySlot(idx);
+    }
+
+private:
+    struct Slot {
+        bool active = false;
+        uint8_t msg_id = 0;
+        void (*dispatch_bytes)(const uint8_t* payload, size_t len,
+                               uint8_t msgId, void* ctx) = nullptr;
+        void (*dispatch_typed)(const void* msg,
+                               uint8_t msgId, void* ctx)  = nullptr;
+        void (*destroy_fn)(void* ctx)                      = nullptr;
+        alignas(alignof(std::max_align_t))
+            uint8_t callable_storage[MaxCallableSize];
+    };
+
+    Transport*   transport_;
+    frame_parser* parser_;
+    Slot         slots_[MaxSubscriptions];
+    uint8_t      buffer_[MaxBuffer];
+    size_t       buffer_len_;
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    size_t FindFreeSlot() const {
+        for (size_t i = 0; i < MaxSubscriptions; ++i) {
+            if (!slots_[i].active) return i;
+        }
+        return SubscriptionHandle::INVALID;
+    }
+
+    void DestroySlot(size_t idx) {
+        Slot& slot = slots_[idx];
+        if (slot.active && slot.destroy_fn != nullptr) {
+            slot.destroy_fn(slot.callable_storage);
+        }
+        slot.active        = false;
+        slot.dispatch_bytes = nullptr;
+        slot.dispatch_typed = nullptr;
+        slot.destroy_fn    = nullptr;
+    }
+
+    void ParseBuffer() {
+        while (buffer_len_ > 0) {
+            const FrameMsgInfo result = parser_->parse(buffer_, buffer_len_);
+            if (!result.valid) break;
+
+            // Auto-dispatch: deserialize payload and notify all matching slots.
+            Dispatch(result.msg_id, result.msg_data, result.msg_len);
+
+            // Advance past the consumed frame.
+            // frame_size is populated by all profile parsers; fall back to a
+            // conservative estimate only if the parser does not set it.
+            const size_t frameSize =
+                result.frame_size > 0 ? result.frame_size : result.msg_len + 10;
+
+            if (frameSize == 0 || frameSize > buffer_len_) {
+                buffer_len_ = 0; // safety guard: prevents infinite loop
+                break;
+            }
+            std::memmove(buffer_, buffer_ + frameSize, buffer_len_ - frameSize);
+            buffer_len_ -= frameSize;
+        }
+    }
+
+    void Dispatch(uint16_t msgId, const uint8_t* payload, size_t len) {
+        const auto id8 = static_cast<uint8_t>(msgId);
+        for (size_t i = 0; i < MaxSubscriptions; ++i) {
+            Slot& slot = slots_[i];
+            if (slot.active && slot.msg_id == id8 &&
+                slot.dispatch_bytes != nullptr) {
+                slot.dispatch_bytes(payload, len, id8, slot.callable_storage);
+            }
+        }
+    }
+
+    static void DataCallbackWrapper(const uint8_t* data, size_t length,
+                                    void* user_data) {
+        static_cast<StructFrameSdkT*>(user_data)->Feed(data, length);
+    }
+
+    static void ErrorCallbackWrapper(const char*, void*) {}
+
+    static void CloseCallbackWrapper(void* user_data) {
+        static_cast<StructFrameSdkT*>(user_data)->buffer_len_ = 0;
     }
 };
+
+// Convenience alias with default sizing — covers the common case and keeps
+// existing code (StructFrameSdk sdk(config)) compiling unchanged.
+using StructFrameSdk = StructFrameSdkT<>;
 
 } // namespace sdk
 } // namespace structframe

--- a/src/struct_frame/boilerplate/js/frame-base.js
+++ b/src/struct_frame/boilerplate/js/frame-base.js
@@ -63,7 +63,8 @@ function createFrameMsgInfo() {
         msgId: 0,
         msgLen: 0,
         msgData: new Uint8Array(0),
-        status: FrameMsgStatus.None
+        status: FrameMsgStatus.None,
+        frameSize: 0
     };
 }
 // Shared Payload Parsing Functions

--- a/src/struct_frame/boilerplate/js/frame-profiles.js
+++ b/src/struct_frame/boilerplate/js/frame-profiles.js
@@ -351,6 +351,7 @@ function parseFrameWithCrc(config, buffer, getMessageInfo) {
   result.msgId = msgId;
   result.msgLen = msgLen;
   result.msgData = buffer.slice(headerSize, headerSize + msgLen);
+  result.frameSize = totalSize;
 
   return result;
 }
@@ -403,6 +404,7 @@ function parseFrameMinimal(config, buffer, getMessageInfo) {
   result.msgId = msgId;
   result.msgLen = msgLen;
   result.msgData = buffer.slice(headerSize, headerSize + msgLen);
+  result.frameSize = totalSize;
 
   return result;
 }

--- a/src/struct_frame/boilerplate/py/struct_frame_sdk/async_struct_frame_sdk.py
+++ b/src/struct_frame/boilerplate/py/struct_frame_sdk/async_struct_frame_sdk.py
@@ -153,16 +153,16 @@ class AsyncStructFrameSdk:
             self.buffer = self.buffer[total_frame_size:]
 
     def _calculate_frame_size(self, result) -> int:
-        """Calculate total frame size including headers and footers
+        """Calculate total frame size including headers and footers.
         
-        Frame overhead by format:
-        - BasicDefault: 2 start + 1 length + 1 msg_id + payload + 2 crc = 6 + payload
-        - TinyDefault: 1 start + 1 length + 1 msg_id + payload + 2 crc = 5 + payload
-        
-        Using conservative estimate of 10 bytes to handle all frame formats.
-        TODO: Query frame parser for exact overhead to avoid buffering issues.
+        Uses frame_size from the parser result when available (set by
+        profiles that track total frame size during parsing). Falls back
+        to re-framing the parsed payload so older parsers still trim the
+        exact frame length without relying on a guessed overhead.
         """
-        return result.msg_len + 10
+        if result.frame_size > 0:
+            return result.frame_size
+        return len(self.frame_parser.frame(result.msg_id, result.msg_data))
 
     def _handle_error(self, error: Exception) -> None:
         """Handle transport error"""

--- a/src/struct_frame/boilerplate/py/struct_frame_sdk/struct_frame_sdk.py
+++ b/src/struct_frame/boilerplate/py/struct_frame_sdk/struct_frame_sdk.py
@@ -152,16 +152,16 @@ class StructFrameSdk:
             self.buffer = self.buffer[total_frame_size:]
 
     def _calculate_frame_size(self, result) -> int:
-        """Calculate total frame size including headers and footers
+        """Calculate total frame size including headers and footers.
         
-        Frame overhead by format:
-        - BasicDefault: 2 start + 1 length + 1 msg_id + payload + 2 crc = 6 + payload
-        - TinyDefault: 1 start + 1 length + 1 msg_id + payload + 2 crc = 5 + payload
-        
-        Using conservative estimate of 10 bytes to handle all frame formats.
-        TODO: Query frame parser for exact overhead to avoid buffering issues.
+        Uses frame_size from the parser result when available (set by
+        profiles that track total frame size during parsing). Falls back
+        to re-framing the parsed payload so older parsers still trim the
+        exact frame length without relying on a guessed overhead.
         """
-        return result.msg_len + 10
+        if result.frame_size > 0:
+            return result.frame_size
+        return len(self.frame_parser.frame(result.msg_id, result.msg_data))
 
     def _handle_error(self, error: Exception) -> None:
         """Handle transport error"""

--- a/src/struct_frame/boilerplate/ts/frame-base.ts
+++ b/src/struct_frame/boilerplate/ts/frame-base.ts
@@ -65,6 +65,7 @@ export interface FrameMsgInfo {
     msgLen: number;
     msgData: Uint8Array;
     status: FrameMsgStatus;
+    frameSize?: number;
 }
 
 // Create default FrameMsgInfo
@@ -74,7 +75,8 @@ export function createFrameMsgInfo(): FrameMsgInfo {
         msgId: 0,
         msgLen: 0,
         msgData: new Uint8Array(0),
-        status: FrameMsgStatus.None
+        status: FrameMsgStatus.None,
+        frameSize: 0
     };
 }
 

--- a/src/struct_frame/boilerplate/ts/frame-profiles.ts
+++ b/src/struct_frame/boilerplate/ts/frame-profiles.ts
@@ -405,6 +405,7 @@ export function parseFrameWithCrc(
     result.msgId = msgId;
     result.msgLen = msgLen;
     result.msgData = buffer.slice(headerSize, headerSize + msgLen);
+    result.frameSize = totalSize;
 
     return result;
 }
@@ -461,6 +462,7 @@ export function parseFrameMinimal(
     result.msgId = msgId;
     result.msgLen = msgLen;
     result.msgData = buffer.slice(headerSize, headerSize + msgLen);
+    result.frameSize = totalSize;
 
     return result;
 }

--- a/src/struct_frame/boilerplate/ts/struct-frame-sdk/struct-frame-sdk.ts
+++ b/src/struct_frame/boilerplate/ts/struct-frame-sdk/struct-frame-sdk.ts
@@ -201,7 +201,7 @@ export class StructFrameSdk {
     // profiles that track total frame size during parsing). Falls back
     // to re-framing the parsed payload so older parsers still trim the
     // exact frame length without relying on a guessed overhead.
-    if (result.frameSize > 0) {
+    if (typeof result.frameSize === 'number' && result.frameSize > 0) {
       return result.frameSize;
     }
     return this.frameParser.frame(result.msgId, result.msgData).length;

--- a/src/struct_frame/boilerplate/ts/struct-frame-sdk/struct-frame-sdk.ts
+++ b/src/struct_frame/boilerplate/ts/struct-frame-sdk/struct-frame-sdk.ts
@@ -196,12 +196,15 @@ export class StructFrameSdk {
   }
 
   private calculateFrameSize(result: FrameMsgInfo): number {
-    // Calculate total frame size including headers and footers
-    // For BasicDefault format: 2 start bytes + 1 length + 1 msg_id + payload + 2 crc = 6 + payload
-    // For TinyDefault format: 1 start byte + 1 length + 1 msg_id + payload + 2 crc = 5 + payload
-    // Using conservative estimate of 10 bytes overhead to handle various frame formats
-    // TODO: Query frame parser for exact overhead to avoid buffering issues
-    return result.msgLen + 10;
+    // Calculate total frame size including headers and footers.
+    // Uses frameSize from the parser result when available (set by
+    // profiles that track total frame size during parsing). Falls back
+    // to re-framing the parsed payload so older parsers still trim the
+    // exact frame length without relying on a guessed overhead.
+    if (result.frameSize > 0) {
+      return result.frameSize;
+    }
+    return this.frameParser.frame(result.msgId, result.msgData).length;
   }
 
   private handleError(error: Error): void {

--- a/src/struct_frame/c_gen.py
+++ b/src/struct_frame/c_gen.py
@@ -7,7 +7,7 @@ This module generates C code for struct serialization with manual Pack/Unpack
 functions for binary compatibility across platforms.
 """
 
-from struct_frame import version, NamingStyleC, camel_to_snake_case, pascal_case, build_enum_leading_comments, build_enum_values, get_discriminator_enum_name, build_discriminator_enum_values
+from struct_frame import version, NamingStyleC, camel_to_snake_case, pascal_case, build_enum_leading_comments, build_enum_values, get_discriminator_enum_name, build_discriminator_enum_values, normalize_bytes_type
 import time
 
 _style_c = NamingStyleC()
@@ -24,6 +24,7 @@ c_types = {"uint8": "uint8_t",
            "uint64": 'uint64_t',
            "int64":  'int64_t',
            "string": "char",  # Add string type support
+           "bytes": "char",   # bytes treated identically to string (same wire format)
            }
 
 
@@ -131,7 +132,7 @@ class FieldCGen():
 
         # Handle arrays
         if field.is_array:
-            if field.field_type == "string":
+            if field.field_type in ("string", "bytes"):
                 # String arrays need both array size and individual string size
                 if field.size_option is not None:
                     # Fixed string array: size_option strings, each element_size chars
@@ -163,7 +164,7 @@ class FieldCGen():
             result += f"    {declaration}{comment}"
 
         # Handle regular strings
-        elif field.field_type == "string":
+        elif field.field_type in ("string", "bytes"):
             if field.size_option is not None:
                 # Fixed string: exactly size_option characters
                 declaration = f"char {var_name}[{field.size_option}];"
@@ -273,7 +274,7 @@ class MessageCGen():
         
         # Handle arrays
         if field.is_array:
-            if field.field_type == "string":
+            if field.field_type in ("string", "bytes"):
                 if field.size_option is not None:
                     # Fixed string array: memcmp
                     return f'(memcmp(a->{var_name}, b->{var_name}, sizeof(a->{var_name})) == 0)'
@@ -294,7 +295,7 @@ class MessageCGen():
                     return f'(memcmp(a->{var_name}, b->{var_name}, sizeof(a->{var_name})) == 0)'
         
         # Handle regular strings
-        elif field.field_type == "string":
+        elif field.field_type in ("string", "bytes"):
             if field.size_option is not None:
                 # Fixed string: strncmp
                 return f'(strncmp(a->{var_name}, b->{var_name}, {field.size_option}) == 0)'
@@ -443,7 +444,7 @@ class MessageCGen():
             var_name = field.name
             if field.is_array and field.max_size is not None:
                 # Variable array: count byte + actual data
-                if field.field_type == "string":
+                if field.field_type in ("string", "bytes"):
                     element_size = field.element_size if field.element_size else 1
                     result += f'    size += 1 + (msg->{var_name}.count * {element_size});  // {var_name}: count + data\n'
                 else:
@@ -456,7 +457,7 @@ class MessageCGen():
                         # For nested messages, we need the actual size
                         element_size = (field.size - 1) // field.max_size
                     result += f'    size += 1 + (msg->{var_name}.count * {element_size});  // {var_name}: count + data\n'
-            elif field.field_type == "string" and field.max_size is not None:
+            elif field.field_type in ("string", "bytes") and field.max_size is not None:
                 # Variable string: length byte + actual data
                 result += f'    size += 1 + msg->{var_name}.length;  // {var_name}: length + data\n'
             else:
@@ -508,7 +509,7 @@ class MessageCGen():
             var_name = field.name
             if field.is_array and field.max_size is not None:
                 # Variable array
-                if field.field_type == "string":
+                if field.field_type in ("string", "bytes"):
                     element_size = field.element_size if field.element_size else 1
                     result += f'    // {var_name}: variable string array\n'
                     result += f'    buffer[offset++] = msg->{var_name}.count;\n'
@@ -524,7 +525,7 @@ class MessageCGen():
                     result += f'    buffer[offset++] = msg->{var_name}.count;\n'
                     result += f'    memcpy(buffer + offset, msg->{var_name}.data, msg->{var_name}.count * {element_size});\n'
                     result += f'    offset += msg->{var_name}.count * {element_size};\n'
-            elif field.field_type == "string" and field.max_size is not None:
+            elif field.field_type in ("string", "bytes") and field.max_size is not None:
                 # Variable string
                 result += f'    // {var_name}: variable string\n'
                 result += f'    buffer[offset++] = msg->{var_name}.length;\n'
@@ -597,7 +598,7 @@ class MessageCGen():
             var_name = field.name
             if field.is_array and field.max_size is not None:
                 # Variable array
-                if field.field_type == "string":
+                if field.field_type in ("string", "bytes"):
                     element_size = field.element_size if field.element_size else 1
                     result += f'    // {var_name}: variable string array\n'
                     result += f'    if (offset >= buffer_size) return 0;\n'
@@ -619,7 +620,7 @@ class MessageCGen():
                     result += f'    if (offset + msg->{var_name}.count * {element_size} > buffer_size) return 0;\n'
                     result += f'    memcpy(msg->{var_name}.data, buffer + offset, msg->{var_name}.count * {element_size});\n'
                     result += f'    offset += msg->{var_name}.count * {element_size};\n'
-            elif field.field_type == "string" and field.max_size is not None:
+            elif field.field_type in ("string", "bytes") and field.max_size is not None:
                 # Variable string
                 result += f'    // {var_name}: variable string\n'
                 result += f'    if (offset >= buffer_size) return 0;\n'
@@ -1006,7 +1007,7 @@ class TestCGen():
         out = ""
 
         if field.is_array:
-            if type_name == "string":
+            if type_name in ("string", "bytes"):
                 if field.size_option is not None:
                     count = min(field.size_option, 3)
                     for i in range(count):
@@ -1031,7 +1032,7 @@ class TestCGen():
                         for i in range(count):
                             out += f'    {prefix}.{var_name}.data[{i}] = {TestCGen._dummy_value(field, i)};\n'
                     # else: nested struct array – leave .data zero-initialised
-        elif type_name == "string":
+        elif type_name in ("string", "bytes"):
             if field.size_option is not None:
                 out += f'    strncpy({prefix}.{var_name}, "test_string", sizeof({prefix}.{var_name}) - 1);\n'
             elif field.max_size is not None:
@@ -1214,9 +1215,9 @@ class TestCGen():
         yield '        size_t passed = sf_run_all_tests_for_profile(p, verbose);\n'
         yield '        if (passed != SF_TEST_MESSAGE_COUNT) {\n'
         yield '            all_ok = false;\n'
-        yield '            printf("[FAIL] %s: %zu/%d passed\\n", p->name, passed, SF_TEST_MESSAGE_COUNT);\n'
+        yield f'            printf("[FAIL] %s: %zu/%d passed\\n", p->name, passed, SF_TEST_MESSAGE_COUNT);\n'
         yield '        } else if (verbose) {\n'
-        yield '            printf("[OK] %s: %zu/%d passed\\n", p->name, passed, SF_TEST_MESSAGE_COUNT);\n'
+        yield f'            printf("[OK] %s: %zu/%d passed\\n", p->name, passed, SF_TEST_MESSAGE_COUNT);\n'
         yield '        }\n'
         yield '    }\n'
         yield '    return all_ok;\n'

--- a/src/struct_frame/cpp_gen.py
+++ b/src/struct_frame/cpp_gen.py
@@ -24,6 +24,7 @@ cpp_types = {"uint8": "uint8_t",
              "uint64": 'uint64_t',
              "int64":  'int64_t',
              "string": "char",
+             "bytes": "char",   # bytes treated identically to string (same wire format)
              }
 
 
@@ -111,7 +112,7 @@ class FieldCppGen():
 
         # Handle arrays
         if field.is_array:
-            if field.field_type == "string":
+            if field.field_type in ("string", "bytes"):
                 # String arrays need both array size and individual string size
                 if field.size_option is not None:
                     # Fixed string array: size_option strings, each element_size chars
@@ -143,7 +144,7 @@ class FieldCppGen():
             result += f"    {declaration}{comment}"
 
         # Handle regular strings
-        elif field.field_type == "string":
+        elif field.field_type in ("string", "bytes"):
             if field.size_option is not None:
                 # Fixed string: exactly size_option characters
                 declaration = f"char {var_name}[{field.size_option}];"
@@ -273,7 +274,7 @@ class MessageCppGen():
             return MessageCppGen._mem_compare_expr(var_name)
         
         # String fields need special handling
-        if field.field_type == "string":
+        if field.field_type in ("string", "bytes"):
             if has_fixed_size:
                 return f'(std::strncmp({var_name}, other.{var_name}, {field.size_option}) == 0)'
             if has_max_size:
@@ -447,12 +448,12 @@ class MessageCppGen():
             if field.is_array and field.max_size is not None:
                 # Variable array
                 type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
-                if field.field_type == "string":
+                if field.field_type in ("string", "bytes"):
                     element_size = field.element_size if field.element_size else 1
                 else:
                     element_size = type_sizes.get(field.field_type, (field.size - 1) // field.max_size)
                 result += f'        size += 1 + ({var_name}.count * {element_size});  // {var_name}\n'
-            elif field.field_type == "string" and field.max_size is not None:
+            elif field.field_type in ("string", "bytes") and field.max_size is not None:
                 # Variable string
                 result += f'        size += 1 + {var_name}.length;  // {var_name}\n'
             else:
@@ -501,14 +502,14 @@ class MessageCppGen():
             var_name = field.name
             if field.is_array and field.max_size is not None:
                 type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
-                if field.field_type == "string":
+                if field.field_type in ("string", "bytes"):
                     element_size = field.element_size if field.element_size else 1
                 else:
                     element_size = type_sizes.get(field.field_type, (field.size - 1) // field.max_size)
                 result += f'        buffer[offset++] = {var_name}.count;\n'
                 result += f'        std::memcpy(buffer + offset, {var_name}.data, {var_name}.count * {element_size});\n'
                 result += f'        offset += {var_name}.count * {element_size};\n'
-            elif field.field_type == "string" and field.max_size is not None:
+            elif field.field_type in ("string", "bytes") and field.max_size is not None:
                 result += f'        buffer[offset++] = {var_name}.length;\n'
                 result += f'        std::memcpy(buffer + offset, {var_name}.data, {var_name}.length);\n'
                 result += f'        offset += {var_name}.length;\n'
@@ -573,7 +574,7 @@ class MessageCppGen():
             var_name = field.name
             if field.is_array and field.max_size is not None:
                 type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
-                if field.field_type == "string":
+                if field.field_type in ("string", "bytes"):
                     element_size = field.element_size if field.element_size else 1
                 else:
                     element_size = type_sizes.get(field.field_type, (field.size - 1) // field.max_size)
@@ -583,7 +584,7 @@ class MessageCppGen():
                 result += f'        if (offset + {var_name}.count * {element_size} > buffer_size) return 0;\n'
                 result += f'        std::memcpy({var_name}.data, buffer + offset, {var_name}.count * {element_size});\n'
                 result += f'        offset += {var_name}.count * {element_size};\n'
-            elif field.field_type == "string" and field.max_size is not None:
+            elif field.field_type in ("string", "bytes") and field.max_size is not None:
                 result += f'        if (offset >= buffer_size) return 0;\n'
                 result += f'        {var_name}.length = buffer[offset++];\n'
                 result += f'        if ({var_name}.length > {field.max_size}) {var_name}.length = {field.max_size};\n'
@@ -751,7 +752,7 @@ class MessageCppGen():
                 else:
                     cpp_type = '%s%s' % (pascal_case(f.package), f.field_type)
             
-            if f.is_array or f.field_type == "string":
+            if f.is_array or f.field_type in ("string", "bytes"):
                 pass  # Skip arrays/strings for simplicity
             else:
                 param_list.append(f'{cpp_type} {f.name}')
@@ -765,7 +766,7 @@ class MessageCppGen():
             result += f'     * @tparam T The payload message type (must be one of the valid types)\n'
             result += f'     * @param payload The message to wrap\n'
             for f_name, f in msg.fields.items():
-                if f.is_array or f.field_type == "string":
+                if f.is_array or f.field_type in ("string", "bytes"):
                     continue
                 result += f'     * @param {f.name} Envelope field value\n'
             result += f'     * @return A fully initialized {structName} envelope\n'
@@ -821,7 +822,7 @@ class MessageCppGen():
                 result += f'     * Create a {structName} envelope wrapping a {payload_type} payload.\n'
                 result += f'     * @param payload The {payload_type} message to wrap\n'
                 for f_name, f in msg.fields.items():
-                    if f.is_array or f.field_type == "string":
+                    if f.is_array or f.field_type in ("string", "bytes"):
                         continue
                     result += f'     * @param {f.name} Envelope field value\n'
                 result += f'     * @return A fully initialized {structName} envelope\n'
@@ -1028,7 +1029,7 @@ class TestCppGen():
         
         if type_name in type_values:
             return type_values[type_name]
-        elif type_name == "string":
+        elif type_name in ("string", "bytes"):
             return f'"test_{index}"'
         elif field.is_enum:
             # Return the first enum value - this is a safe default
@@ -1061,7 +1062,7 @@ class TestCppGen():
             if field.size_option is not None:
                 # Fixed array
                 for i in range(min(field.size_option, 3)):  # Initialize first 3 elements
-                    if type_name == "string":
+                    if type_name in ("string", "bytes"):
                         result += f'    std::strncpy({prefix}.{var_name}[{i}], "test_{i}", sizeof({prefix}.{var_name}[{i}]) - 1);\n'
                     else:
                         result += f"    {prefix}.{var_name}[{i}] = {TestCppGen._get_dummy_value(field, use_namespace, i)};\n"
@@ -1070,12 +1071,12 @@ class TestCppGen():
                 num_elements = min(field.max_size, 3)
                 result += f"    {prefix}.{var_name}.count = {num_elements};\n"
                 for i in range(num_elements):
-                    if type_name == "string":
+                    if type_name in ("string", "bytes"):
                         result += f'    std::strncpy({prefix}.{var_name}.data[{i}], "test_{i}", sizeof({prefix}.{var_name}.data[{i}]) - 1);\n'
                     else:
                         result += f"    {prefix}.{var_name}.data[{i}] = {TestCppGen._get_dummy_value(field, use_namespace, i)};\n"
         # Handle regular strings
-        elif type_name == "string":
+        elif type_name in ("string", "bytes"):
             if field.size_option is not None:
                 # Fixed string
                 result += f'    std::strncpy({prefix}.{var_name}, "test_string", sizeof({prefix}.{var_name}) - 1);\n'

--- a/src/struct_frame/csharp_gen.py
+++ b/src/struct_frame/csharp_gen.py
@@ -166,7 +166,7 @@ class FieldCSharpGen():
         if type_name in csharp_types:
             base_type = csharp_types[type_name]
         else:
-            # Use the type name directly ΓÇö namespace/using directives handle scoping
+            # Use the type name directly - namespace/using directives handle scoping
             type_pkg = field.type_package if field.type_package else field.package
             base_type = renamed_enums.get(type_name, type_name) if renamed_enums else type_name
 
@@ -625,7 +625,7 @@ class MessageCSharpGen():
         result += '\n'
         result += '        /// <summary>\n'
         result += '        /// Deserialize a <see cref="ReadOnlySpan{byte}"/> into this message type.\n'
-        result += '        /// This is the primary implementation ΓÇö the <c>byte[]</c> and\n'
+        result += '        /// This is the primary implementation - the <c>byte[]</c> and\n'
         result += '        /// <see cref="FrameMsgInfo"/> overloads delegate here.\n'
         if msg.variable:
             result += '        /// For variable messages: auto-detects MAX_SIZE vs variable encoding.\n'
@@ -721,7 +721,7 @@ class MessageCSharpGen():
         result += '            return msg;\n'
         result += '        }\n'
 
-        # byte[] overload ΓÇö delegates to the span overload (keeps API compatibility)
+        # byte[] overload - delegates to the span overload (keeps API compatibility)
         result += '\n'
         result += '        /// <summary>\n'
         result += '        /// Deserialize a byte array. Delegates to <see cref="Deserialize(ReadOnlySpan{byte})"/>.\n'
@@ -1002,7 +1002,7 @@ class MessageCSharpGen():
         result += '        }\n'
         
         # Generate _DeserializeVariable static method (internal method)
-        # Keeps byte[] parameter ΓÇö variable messages receive a freshly-allocated slice
+        # Keeps byte[] parameter - variable messages receive a freshly-allocated slice
         # from the span dispatch path (data.ToArray()), so no additional allocation occurs.
         result += '\n'
         result += '        /// <summary>\n'
@@ -1969,7 +1969,7 @@ class TestCSharpGen():
             elif field.is_enum:
                 pass  # enum left at default 0 value
             else:
-                # Nested message ΓÇô default-construct
+                # Nested message - default-construct
                 out += f'        {prefix}.{var_name} = new {type_name}();\n'
         return out
 

--- a/src/struct_frame/csharp_gen.py
+++ b/src/struct_frame/csharp_gen.py
@@ -7,7 +7,7 @@ This module generates C# code for struct serialization using
 classes with manual Pack/Unpack methods for binary compatibility.
 """
 
-from struct_frame import version, NamingStyleC, camel_to_snake_case, pascal_case, build_enum_leading_comments, build_enum_values, get_discriminator_enum_name, build_discriminator_enum_values
+from struct_frame import version, NamingStyleC, camel_to_snake_case, pascal_case, build_enum_leading_comments, build_enum_values, get_discriminator_enum_name, build_discriminator_enum_values, normalize_bytes_type
 import os
 import time
 
@@ -27,6 +27,7 @@ csharp_types = {
     "uint64": "ulong",
     "int64": "long",
     "string": "byte[]",
+    "bytes": "byte[]",
 }
 
 # Mapping from proto types to byte sizes
@@ -154,7 +155,7 @@ class FieldCSharpGen():
         """Generate C# field declaration"""
         result = ''
         var_name = pascal_case(field.name)
-        type_name = field.field_type
+        type_name = normalize_bytes_type(field.field_type)
 
         # Add leading comments
         leading_comment = field.comments
@@ -165,13 +166,13 @@ class FieldCSharpGen():
         if type_name in csharp_types:
             base_type = csharp_types[type_name]
         else:
-            # Use the type name directly — namespace/using directives handle scoping
+            # Use the type name directly ΓÇö namespace/using directives handle scoping
             type_pkg = field.type_package if field.type_package else field.package
             base_type = renamed_enums.get(type_name, type_name) if renamed_enums else type_name
 
         # Handle arrays
         if field.is_array:
-            if field.field_type == "string":
+            if type_name == "string":
                 # String arrays
                 if field.size_option is not None:
                     # Fixed string array
@@ -199,7 +200,7 @@ class FieldCSharpGen():
                         result += f'        public {base_type}[] {var_name}Data {{ get; set; }} = null!;  // Variable array: up to {field.max_size} elements\n'
 
         # Handle regular strings
-        elif field.field_type == "string":
+        elif type_name == "string":
             if field.size_option is not None:
                 # Fixed string
                 result += f'        public byte[] {var_name} {{ get; set; }} = null!;  // Fixed string: exactly {field.size_option} chars\n'
@@ -242,7 +243,7 @@ class FieldCSharpGen():
         """
         lines = []
         var_name = pascal_case(field.name)
-        type_name = field.field_type
+        type_name = normalize_bytes_type(field.field_type)
         
         # Local helper to format offset expressions
         def fmt_offset(off):
@@ -252,7 +253,7 @@ class FieldCSharpGen():
 
         # IMPORTANT: Check is_array FIRST to handle arrays of primitives correctly
         if field.is_array:
-            if field.field_type == "string":
+            if type_name == "string":
                 if field.size_option is not None:
                     # Fixed string array
                     total_size = field.size_option * field.element_size
@@ -328,7 +329,7 @@ class FieldCSharpGen():
                 lines.append(f'            BinaryPrimitives.WriteDoubleLittleEndian(buffer.AsSpan({fmt_offset(base_offset)}, 8), {var_name});')
             elif type_name == "bool":
                 lines.append(f'            buffer[{fmt_offset(base_offset)}] = (byte)({var_name} ? 1 : 0);')
-        elif field.field_type == "string":
+        elif type_name == "string":
             if field.size_option is not None:
                 # Fixed string
                 lines.append(f'            if ({var_name} != null) Array.Copy({var_name}, 0, buffer, {fmt_offset(base_offset)}, Math.Min({var_name}.Length, {field.size_option}));')
@@ -359,11 +360,11 @@ class FieldCSharpGen():
         """Generate code to unpack this field from a ReadOnlySpan<byte>."""
         lines = []
         var_name = pascal_case(field.name)
-        type_name = field.field_type
+        type_name = normalize_bytes_type(field.field_type)
 
         # IMPORTANT: Check is_array FIRST to handle arrays of primitives correctly
         if field.is_array:
-            if field.field_type == "string":
+            if normalize_bytes_type(field.field_type) == "string":
                 if field.size_option is not None:
                     # Fixed string array
                     total_size = field.size_option * field.element_size
@@ -448,7 +449,7 @@ class FieldCSharpGen():
                 lines.append(f'            msg.{var_name} = BinaryPrimitives.ReadDoubleLittleEndian(data.Slice({offset}, 8));')
             elif type_name == "bool":
                 lines.append(f'            msg.{var_name} = data[{offset}] != 0;')
-        elif field.field_type == "string":
+        elif normalize_bytes_type(field.field_type) == "string":
             if field.size_option is not None:
                 # Fixed string
                 lines.append(f'            msg.{var_name} = new byte[{field.size_option}];')
@@ -624,7 +625,7 @@ class MessageCSharpGen():
         result += '\n'
         result += '        /// <summary>\n'
         result += '        /// Deserialize a <see cref="ReadOnlySpan{byte}"/> into this message type.\n'
-        result += '        /// This is the primary implementation — the <c>byte[]</c> and\n'
+        result += '        /// This is the primary implementation ΓÇö the <c>byte[]</c> and\n'
         result += '        /// <see cref="FrameMsgInfo"/> overloads delegate here.\n'
         if msg.variable:
             result += '        /// For variable messages: auto-detects MAX_SIZE vs variable encoding.\n'
@@ -720,7 +721,7 @@ class MessageCSharpGen():
         result += '            return msg;\n'
         result += '        }\n'
 
-        # byte[] overload — delegates to the span overload (keeps API compatibility)
+        # byte[] overload ΓÇö delegates to the span overload (keeps API compatibility)
         result += '\n'
         result += '        /// <summary>\n'
         result += '        /// Deserialize a byte array. Delegates to <see cref="Deserialize(ReadOnlySpan{byte})"/>.\n'
@@ -867,7 +868,7 @@ class MessageCSharpGen():
             type_name = f.field_type
             if f.is_array and f.max_size is not None:
                 type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
-                if type_name == "string":
+                if normalize_bytes_type(type_name) == "string":
                     element_size = f.element_size if f.element_size else 1
                 else:
                     element_size = type_sizes.get(type_name, (f.size - 1) // f.max_size)
@@ -886,7 +887,7 @@ class MessageCSharpGen():
                     result += f'                for (int i = 0; i < {var_name}Count; i++)\n'
                     result += f'                    if ({var_name}Data[i] != null) {{ var bytes = {var_name}Data[i].Serialize(); Array.Copy(bytes, 0, buffer, offset + i * {element_size}, bytes.Length); }}\n'
                     result += f'            offset += {var_name}Count * {element_size};\n'
-            elif type_name == "string" and f.max_size is not None:
+            elif normalize_bytes_type(type_name) == "string" and f.max_size is not None:
                 result += f'            // {f.name}: variable string\n'
                 result += f'            buffer[offset++] = {var_name}Length;\n'
                 result += f'            if ({var_name}Data != null)\n'
@@ -918,7 +919,7 @@ class MessageCSharpGen():
                         result += f'            BinaryPrimitives.WriteDoubleLittleEndian(buffer.AsSpan(offset, 8), {var_name}); offset += 8;\n'
                     elif type_name == "bool":
                         result += f'            buffer[offset++] = (byte)({var_name} ? 1 : 0);\n'
-                elif type_name == "string" and f.size_option is not None:
+                elif normalize_bytes_type(type_name) == "string" and f.size_option is not None:
                     # Fixed string - copy from byte array
                     result += f'            if ({var_name} != null)\n'
                     result += f'                Array.Copy({var_name}, 0, buffer, offset, Math.Min({var_name}.Length, {f.size}));\n'
@@ -1001,7 +1002,7 @@ class MessageCSharpGen():
         result += '        }\n'
         
         # Generate _DeserializeVariable static method (internal method)
-        # Keeps byte[] parameter — variable messages receive a freshly-allocated slice
+        # Keeps byte[] parameter ΓÇö variable messages receive a freshly-allocated slice
         # from the span dispatch path (data.ToArray()), so no additional allocation occurs.
         result += '\n'
         result += '        /// <summary>\n'
@@ -1017,7 +1018,7 @@ class MessageCSharpGen():
             type_name = f.field_type
             if f.is_array and f.max_size is not None:
                 type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
-                if type_name == "string":
+                if normalize_bytes_type(type_name) == "string":
                     element_size = f.element_size if f.element_size else 1
                 else:
                     count_size = 2 if f.max_size > 255 else 1
@@ -1044,7 +1045,7 @@ class MessageCSharpGen():
                     result += f'            for (int i = 0; i < msg.{var_name}Count; i++)\n'
                     result += f'                msg.{var_name}Data[i] = {nested_type}.Deserialize(data[(offset + i * {element_size})..(offset + (i + 1) * {element_size})]);\n'
                     result += f'            offset += msg.{var_name}Count * {element_size};\n'
-            elif type_name == "string" and f.max_size is not None:
+            elif normalize_bytes_type(type_name) == "string" and f.max_size is not None:
                 result += f'            // {f.name}: variable string\n'
                 if f.max_size > 255:
                     result += f'            msg.{var_name}Length = Math.Min(BinaryPrimitives.ReadUInt16LittleEndian(data.AsSpan(offset, 2)), (ushort){f.max_size});\n'
@@ -1079,7 +1080,7 @@ class MessageCSharpGen():
                         result += f'            msg.{var_name} = BinaryPrimitives.ReadDoubleLittleEndian(data.AsSpan(offset, 8)); offset += 8;\n'
                     elif type_name == "bool":
                         result += f'            msg.{var_name} = data[offset++] != 0;\n'
-                elif type_name == "string" and f.size_option is not None:
+                elif normalize_bytes_type(type_name) == "string" and f.size_option is not None:
                     # Fixed string - copy into byte array
                     result += f'            msg.{var_name} = new byte[{f.size}];\n'
                     result += f'            data.AsSpan(offset, {f.size}).CopyTo(msg.{var_name}.AsSpan());\n'
@@ -1906,7 +1907,7 @@ class TestCSharpGen():
         out = ""
 
         if field.is_array:
-            if type_name == "string":
+            if normalize_bytes_type(type_name) == "string":
                 if field.size_option is not None:
                     # Fixed string array: byte[] flattened, size_option strings * element_size bytes
                     total = field.size_option * field.element_size
@@ -1954,7 +1955,7 @@ class TestCSharpGen():
                         out += f'        {prefix}.{var_name}Data = new {elem_type}[] {{ '
                         out += ', '.join(TestCSharpGen._dummy_value(field, i) for i in range(count))
                         out += ' };\n'
-        elif type_name == "string":
+        elif normalize_bytes_type(type_name) == "string":
             if field.size_option is not None:
                 out += f'        {prefix}.{var_name} = {TestCSharpGen._bytes_literal("test_string", field.size_option)};\n'
             elif field.max_size is not None:
@@ -1968,7 +1969,7 @@ class TestCSharpGen():
             elif field.is_enum:
                 pass  # enum left at default 0 value
             else:
-                # Nested message – default-construct
+                # Nested message ΓÇô default-construct
                 out += f'        {prefix}.{var_name} = new {type_name}();\n'
         return out
 

--- a/src/struct_frame/generate.py
+++ b/src/struct_frame/generate.py
@@ -42,7 +42,8 @@ default_types = {
     "double": {"size": 8},
     "int64": {"size": 8},
     "uint64": {"size": 8},
-    "string": {"size": 4}  # Variable length, estimated size for length prefix
+    "string": {"size": 4},  # Variable length, estimated size for length prefix
+    "bytes": {"size": 4},   # Variable length byte array, same wire format as string
 }
 
 # Type codes for magic number calculation
@@ -59,6 +60,7 @@ type_codes = {
     "int64": 10,
     "uint64": 11,
     "string": 12,
+    "bytes": 14,  # Raw byte array (distinct from string for magic number purposes)
     "enum": 13,  # Fixed code for all enum types (name-independent)
 }
 
@@ -581,7 +583,7 @@ class Field:
 
         # Calculate size for arrays and strings
         if self.is_array:
-            if self.field_type == "string":
+            if self.field_type in ("string", "bytes"):
                 # String arrays need both array size AND individual element size
                 if self.element_size is None:
                     print(
@@ -613,7 +615,7 @@ class Field:
                     print(
                         f"Array field {self.name} missing required size or max_size option")
                     return False
-        elif self.field_type == "string":
+        elif self.field_type in ("string", "bytes"):
             if self.size_option is not None:
                 # Fixed string: exactly size_option characters
                 self.size = self.size_option
@@ -632,7 +634,7 @@ class Field:
         if debug:
             array_info = ""
             if self.is_array:
-                if self.field_type == "string":
+                if self.field_type in ("string", "bytes"):
                     # String arrays show both array size and individual element size
                     if self.size_option is not None:
                         array_info = f", fixed_string_array size={self.size_option}, element_size={self.element_size}"
@@ -644,7 +646,7 @@ class Field:
                         array_info = f", fixed_array size={self.size_option}"
                     elif self.max_size is not None:
                         array_info = f", bounded_array max_size={self.max_size}"
-            elif self.field_type == "string":
+            elif self.field_type in ("string", "bytes"):
                 # Regular strings
                 if self.size_option is not None:
                     array_info = f", fixed_string size={self.size_option}"
@@ -667,7 +669,7 @@ class Field:
                 array_info = f", Array[max_size={self.max_size}]"
             else:
                 array_info = ", Array[no size specified]"
-        elif self.field_type == "string":
+        elif self.field_type in ("string", "bytes"):
             if self.size_option is not None:
                 array_info = f", String[size={self.size_option}]"
             elif self.max_size is not None:
@@ -1201,7 +1203,7 @@ class Message:
                     print(
                         f"Array field {key} in Message {self.name}: must specify size or max_size option")
                     return False
-            elif value.field_type == "string":
+            elif value.field_type in ("string", "bytes"):
                 # Strings must have size or max_size specified
                 if value.size_option is None and value.max_size is None:
                     print(
@@ -1270,7 +1272,7 @@ class Message:
                     # Bounded array: only the count bytes (1 or 2, no data when empty)
                     count_bytes = 2 if value.max_size > 255 else 1
                     self.min_size += count_bytes
-                elif value.field_type == "string" and value.max_size is not None:
+                elif value.field_type in ("string", "bytes") and value.max_size is not None:
                     # Variable string: only the length bytes (1 or 2, no data when empty)
                     length_bytes = 2 if value.max_size > 255 else 1
                     self.min_size += length_bytes

--- a/src/struct_frame/generate.py
+++ b/src/struct_frame/generate.py
@@ -494,9 +494,9 @@ class Field:
                         # Variable size for arrays or strings
                         try:
                             self.max_size = int(ovalue)
-                            if self.max_size <= 0 or self.max_size > 255:
+                            if self.max_size <= 0 or self.max_size > 65535:
                                 print(
-                                    f"Invalid max_size {self.max_size} for field {self.name}, must be 1-255")
+                                    f"Invalid max_size {self.max_size} for field {self.name}, must be 1-65535")
                                 return False
                         except (ValueError, TypeError):
                             print(

--- a/src/struct_frame/generate.py
+++ b/src/struct_frame/generate.py
@@ -494,9 +494,9 @@ class Field:
                         # Variable size for arrays or strings
                         try:
                             self.max_size = int(ovalue)
-                            if self.max_size <= 0 or self.max_size > 65535:
+                            if self.max_size <= 0 or self.max_size > 255:
                                 print(
-                                    f"Invalid max_size {self.max_size} for field {self.name}, must be 1-65535")
+                                    f"Invalid max_size {self.max_size} for field {self.name}, must be 1-255")
                                 return False
                         except (ValueError, TypeError):
                             print(
@@ -1006,6 +1006,7 @@ class Message:
         self.magic_bytes = None  # Magic numbers for checksum (byte1, byte2)
         self.magic_bytes_override = None  # User-specified magic bytes (option magic_bytes)
         self.variable = False  # Variable length message encoding
+        self.discriminator_mode = None  # Optional message-level discriminator override
         # True if this message is an envelope/container for other messages
         self.is_envelope = False
         self.source_file = None
@@ -1030,6 +1031,20 @@ class Message:
                     sval = str(e.value).strip().lower()
                     if sval in ('true', '1', 'yes', 'on') or e.value is True:
                         self.variable = True
+                elif e.name == "discriminator":
+                    val = e.value
+                    if hasattr(val, 'name'):
+                        sval = val.name.lower()
+                    else:
+                        sval = str(val).strip().lower().strip('"\'')
+                    if sval in ('auto', 'msgid', 'field_order', 'none', 'false', 'off', 'disabled'):
+                        if sval in ('false', 'off', 'disabled'):
+                            sval = 'none'
+                        self.discriminator_mode = sval
+                    else:
+                        print(f"Invalid discriminator option '{e.value}' in message {self.name}. "
+                              f"Valid values: auto, msgid, field_order, none")
+                        return False
                 elif e.name in ("is_envelope", "envelope"):
                     sval = str(e.value).strip().lower()
                     if sval in ('true', '1', 'yes', 'on') or e.value is True:
@@ -1154,6 +1169,11 @@ class Message:
                 self.base_size = self.base_size + value.size
 
         # Validate oneofs - they contribute their max size to the message
+        if self.discriminator_mode is not None and len(self.oneofs) == 1:
+            sole_oneof = next(iter(self.oneofs.values()))
+            if sole_oneof.discriminator_mode == "auto":
+                sole_oneof.discriminator_mode = self.discriminator_mode
+
         for key, oneof in self.oneofs.items():
             if not oneof.validate(current_package, packages, debug, current_message=self):
                 print(
@@ -1319,6 +1339,7 @@ class Package:
         self.enums = {}
         self.messages = {}
         self.package_id = None  # Package ID for extended message IDs (0-255)
+        self.package_id_explicit = False
 
     def addEnum(self, enum, comments, source_file=None):
         self.comments = comments
@@ -1364,8 +1385,16 @@ class Package:
             # Only error if the same package NAME has different IDs (checked in validate_package_id).
 
         # Validate message IDs based on whether package has a package ID
+        seen_msg_ids = {}
         for key, value in self.messages.items():
             if value.id is not None:
+                if value.id in seen_msg_ids:
+                    other = seen_msg_ids[value.id]
+                    print(
+                        f"Error: duplicate msgid {value.id} in package '{self.name}' used by messages '{other}' and '{value.name}'")
+                    return False
+                seen_msg_ids[value.id] = value.name
+
                 if self.package_id is not None:
                     # If package has a package ID, message IDs must be < 256
                     if value.id < 0 or value.id >= 256:
@@ -1421,6 +1450,12 @@ processed_file = []
 required_file = []
 # Track which package imports which other packages: {importing_pkg: [imported_pkg1, imported_pkg2, ...]}
 package_imports = {}
+# Imports that could not be resolved when first seen because the target
+# package had not been parsed yet: [(importing_pkg, imported_abs_path), ...]
+pending_package_imports = []
+# Track the owning package for each parsed file so repeated imports can still
+# contribute package-level edges even when parseFile short-circuits.
+file_to_package = {}
 
 parser = argparse.ArgumentParser(
     prog='struct_frame',
@@ -1488,6 +1523,10 @@ def parseFile(filename, base_path=None, importing_package=None):
     # Convert to absolute path for circular import detection
     abs_filename = os.path.abspath(filename)
 
+    if not processed_file and not packages and not package_imports:
+        file_to_package.clear()
+        pending_package_imports.clear()
+
     # Avoid circular imports
     if abs_filename in processed_file:
         return True
@@ -1511,6 +1550,18 @@ def parseFile(filename, base_path=None, importing_package=None):
     foundPackage = False
     package_name = ""
     comments = []
+    pending_imports = []
+
+    def record_package_import(importer, import_path):
+        imported_abs_path = os.path.abspath(import_path)
+        imported_package_name = file_to_package.get(imported_abs_path)
+        if not imported_package_name or importer == imported_package_name:
+            return False
+        if importer not in package_imports:
+            package_imports[importer] = []
+        if imported_package_name not in package_imports[importer]:
+            package_imports[importer].append(imported_package_name)
+        return True
 
     for e in result.file_elements:
         if (type(e) == ast.Package):
@@ -1522,12 +1573,13 @@ def parseFile(filename, base_path=None, importing_package=None):
             package_name = e.name
             if package_name not in packages:
                 packages[package_name] = Package(package_name)
+            file_to_package[abs_filename] = package_name
             # Track import relationship if this file was imported
             if importing_package and importing_package != package_name:
-                if importing_package not in package_imports:
-                    package_imports[importing_package] = []
-                if package_name not in package_imports[importing_package]:
-                    package_imports[importing_package].append(package_name)
+                record_package_import(importing_package, abs_filename)
+                for pending_import in pending_imports:
+                    record_package_import(package_name, pending_import)
+                pending_imports.clear()
 
         elif (type(e) == ast.Import):
             # Handle import statements
@@ -1548,6 +1600,13 @@ def parseFile(filename, base_path=None, importing_package=None):
                 print(f"  Tried: {import_path_base}")
                 print(f"  Tried: {import_path_current}")
                 return False
+
+            imported_abs_path = os.path.abspath(import_path)
+            if foundPackage and package_name:
+                if not record_package_import(package_name, imported_abs_path):
+                    pending_package_imports.append((package_name, imported_abs_path))
+            else:
+                pending_imports.append(imported_abs_path)
 
             # Recursively parse the imported file, passing current package as importer
             if not parseFile(import_path, base_path, package_name):
@@ -1588,6 +1647,11 @@ def parseFile(filename, base_path=None, importing_package=None):
         elif (type(e) == ast.Comment):
             comments.append(e.text)
 
+    if foundPackage and pending_imports:
+        for pending_import in pending_imports:
+            if not record_package_import(package_name, pending_import):
+                pending_package_imports.append((package_name, pending_import))
+
     return True
 
 
@@ -1616,6 +1680,7 @@ def validate_package_id(package_name, new_id, filename):
     else:
         # First assignment
         packages[package_name].package_id = new_id
+        packages[package_name].package_id_explicit = True
 
     return True
 
@@ -1641,6 +1706,7 @@ def apply_package_id_inheritance():
                 if importing_pkg_id is not None:
                     # Inheritance: imported package gets the importing package's ID
                     packages[imported_pkg].package_id = importing_pkg_id
+                    packages[imported_pkg].package_id_explicit = False
                 # else: Neither package has an ID - this will be caught by validatePackages if needed
             # If both packages have IDs, they are validated separately
             # Note: Same package name with different IDs is caught by validate_package_id()
@@ -1655,6 +1721,55 @@ def validate_packages(debug=False):
     # Apply package ID inheritance first
     if not apply_package_id_inheritance():
         return False
+
+    # Resolve deferred import edges now that all package/file mappings exist.
+    for importing_pkg, imported_abs_path in pending_package_imports:
+        imported_pkg = file_to_package.get(os.path.abspath(imported_abs_path))
+        if imported_pkg and importing_pkg != imported_pkg:
+            if importing_pkg not in package_imports:
+                package_imports[importing_pkg] = []
+            if imported_pkg not in package_imports[importing_pkg]:
+                package_imports[importing_pkg].append(imported_pkg)
+
+    # Reject package import cycles (A -> B -> A).
+    visiting = set()
+    visited = set()
+
+    def dfs(pkg_name, stack):
+        if pkg_name in visiting:
+            cycle_start = stack.index(pkg_name)
+            cycle = stack[cycle_start:] + [pkg_name]
+            print("Error: circular package import detected: " + " -> ".join(cycle))
+            return False
+        if pkg_name in visited:
+            return True
+
+        visiting.add(pkg_name)
+        stack.append(pkg_name)
+        for dep in package_imports.get(pkg_name, []):
+            if dep in packages and not dfs(dep, stack):
+                return False
+        stack.pop()
+        visiting.remove(pkg_name)
+        visited.add(pkg_name)
+        return True
+
+    for pkg_name in sorted(packages):
+        if not dfs(pkg_name, []):
+            return False
+
+    # Reject duplicate explicit package IDs across compiled packages.
+    seen_pkg_ids = {}
+    for pkg_name in sorted(packages):
+        pkg = packages[pkg_name]
+        if pkg.package_id is None or not pkg.package_id_explicit:
+            continue
+        if pkg.package_id in seen_pkg_ids:
+            other = seen_pkg_ids[pkg.package_id]
+            print(
+                f"Error: duplicate package ID {pkg.package_id} used by packages '{other}' and '{pkg_name}'")
+            return False
+        seen_pkg_ids[pkg.package_id] = pkg_name
 
     # Check if multiple packages exist
     if len(packages) > 1:

--- a/src/struct_frame/gql_gen.py
+++ b/src/struct_frame/gql_gen.py
@@ -23,6 +23,7 @@ gql_types = {
     "float": "Float",
     "double": "Float",
     "string": "String",
+    "bytes": "String",    # bytes treated identically to string (same wire format)
 }
 
 
@@ -104,7 +105,7 @@ class FieldGqlGen:
             # Array field - use our size descriptions
             if getattr(field, 'size_option', None) is not None:
                 # Fixed array
-                if field.field_type == "string":
+                if field.field_type in ("string", "bytes"):
                     comment_lines = [
                         f"Fixed string array: {field.size_option} strings, each {getattr(field, 'element_size', 'N/A')} chars"]
                 else:
@@ -112,13 +113,13 @@ class FieldGqlGen:
                         f"Fixed array: always {field.size_option} elements"]
             else:
                 # Variable array
-                if field.field_type == "string":
+                if field.field_type in ("string", "bytes"):
                     comment_lines = [
                         f"Variable string array: up to {getattr(field, 'max_size', 'N/A')} strings, each max {getattr(field, 'element_size', 'N/A')} chars"]
                 else:
                     comment_lines = [
                         f"Variable array: up to {getattr(field, 'max_size', 'N/A')} elements"]
-        elif field.field_type == "string":
+        elif field.field_type in ("string", "bytes"):
             # Non-array string field
             if getattr(field, 'size_option', None) is not None:
                 comment_lines = [
@@ -171,7 +172,7 @@ class MessageGqlGen:
                 lines.append(desc)
         type_name = f"{pascal_case(msg.package)}{msg.name}"
         lines.append(f'type {type_name} @package(name: "{package.name}") {{')
-        if not msg.fields:
+        if not msg.fields and not getattr(msg, 'oneofs', {}):
             lines.append("  _empty: Boolean")
         else:
             for key, f in msg.fields.items():
@@ -180,6 +181,16 @@ class MessageGqlGen:
                         FieldGqlGen.generate_flattened_children(f, package, msg))
                 else:
                     lines.append(FieldGqlGen.generate(f))
+            # Generate oneof fields as nullable union-type fields
+            for oneof_name, oneof in getattr(msg, 'oneofs', {}).items():
+                lines.append(f"  # oneof {oneof_name}")
+                for field_name, oneof_field in oneof.fields.items():
+                    gql_type = gql_types.get(oneof_field.field_type,
+                                              f"{pascal_case(oneof_field.package)}{oneof_field.field_type}")
+                    if getattr(oneof_field, 'is_array', False):
+                        gql_type = f"[{gql_type}!]!"
+                    # Oneof members are nullable since only one is populated
+                    lines.append(f"  {field_name}: {gql_type}")
         lines.append("}\n")
         return '\n'.join(lines)
 
@@ -199,12 +210,23 @@ class FileGqlGen:
         yield _PACKAGE_DIRECTIVE_DEF + '\n\n'
 
         first_block = True
-        # Enums
+        # Enums (package-level)
         for _, enum in package.enums.items():
             if not first_block:
                 yield '\n'
             first_block = False
             yield EnumGqlGen.generate(enum).rstrip() + '\n'
+
+        # Nested enums (message-scoped)
+        emitted_nested = set()
+        for _, msg in package.sortedMessages().items():
+            for enum_name, enum_obj in getattr(msg, 'enums', {}).items():
+                if enum_name not in emitted_nested:
+                    emitted_nested.add(enum_name)
+                    if not first_block:
+                        yield '\n'
+                    first_block = False
+                    yield EnumGqlGen.generate(enum_obj).rstrip() + '\n'
 
         # Messages (object types)
         for _, msg in package.sortedMessages().items():

--- a/src/struct_frame/js_gen.py
+++ b/src/struct_frame/js_gen.py
@@ -451,12 +451,12 @@ class MessageJsClassGen():
             name = to_camel_case(field.name)
             if field.is_array and field.max_size is not None:
                 type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
-                if field.field_type == "string":
+                if field.field_type in ("string", "bytes"):
                     element_size = field.element_size if field.element_size else 1
                 else:
                     element_size = type_sizes.get(field.field_type, (field.size - 1) // field.max_size)
                 result += f'    size += 1 + (this.{name}Count * {element_size}); // {name}\n'
-            elif field.field_type == "string" and field.max_size is not None:
+            elif field.field_type in ("string", "bytes") and field.max_size is not None:
                 result += f'    size += 1 + this.{name}Length; // {name}\n'
             else:
                 result += f'    size += {field.size}; // {name}\n'
@@ -522,7 +522,7 @@ class MessageJsClassGen():
             field_type = field.field_type
             if field.is_array and field.max_size is not None:
                 type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
-                if field_type == "string":
+                if field_type in ("string", "bytes"):
                     element_size = field.element_size if field.element_size else 1
                 else:
                     element_size = type_sizes.get(field_type, (field.size - 1) // field.max_size)
@@ -538,7 +538,7 @@ class MessageJsClassGen():
                 result += f'      buffer.{write_method_name}(this.{name}Data[i], offset);\n'
                 result += f'      offset += {element_size};\n'
                 result += f'    }}\n'
-            elif field_type == "string" and field.max_size is not None:
+            elif field_type in ("string", "bytes") and field.max_size is not None:
                 result += f'    // {name}: variable string\n'
                 result += f'    const {name}Len = this.{name}Length;\n'
                 result += f'    buffer.writeUInt8({name}Len, offset++);\n'
@@ -614,7 +614,7 @@ class MessageJsClassGen():
             field_type = field.field_type
             if field.is_array and field.max_size is not None:
                 type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
-                if field_type == "string":
+                if field_type in ("string", "bytes"):
                     element_size = field.element_size if field.element_size else 1
                 else:
                     element_size = type_sizes.get(field_type, (field.size - 1) // field.max_size)
@@ -625,7 +625,7 @@ class MessageJsClassGen():
                 result += f'      buffer.copy(msg._buffer, {msg_offset + 1} + i * {element_size}, offset, offset + {element_size});\n'
                 result += f'      offset += {element_size};\n'
                 result += f'    }}\n'
-            elif field_type == "string" and field.max_size is not None:
+            elif field_type in ("string", "bytes") and field.max_size is not None:
                 result += f'    // {name}: variable string\n'
                 result += f'    const {name}Len = Math.min(buffer.readUInt8(offset++), {field.max_size});\n'
                 result += f'    msg._buffer.writeUInt8({name}Len, {msg_offset});\n'
@@ -728,7 +728,7 @@ class MessageJsClassGen():
         
         if field_info.is_array:
             result += MessageJsClassGen._generate_array_accessors(field_info)
-        elif field_type == "string":
+        elif field_type in ("string", "bytes"):
             result += MessageJsClassGen._generate_string_accessors(field_info)
         elif field_info.is_enum or field_type in TYPE_SIZES:
             result += MessageJsClassGen._generate_primitive_accessors(field_info)
@@ -792,7 +792,7 @@ class MessageJsClassGen():
             offset = field_info.offset
             if field_info.is_array or field_info.is_nested:
                 result += f'      {name}: this.{name},\n'
-            elif field_type == "string":
+            elif field_type in ("string", "bytes"):
                 size = field_info.element_size or field_info.size
                 result += f'      {name}: this._readString({offset}, {size}),\n'
             elif field_type == "bool":
@@ -839,7 +839,7 @@ class MessageJsClassGen():
             result += f'  set {name}(value) {{\n'
             result += f'    this._writeStructArray({offset}, {length}, {elem_size}, value, {nested_type});\n'
             result += f'  }}\n\n'
-        elif field_type == "string":
+        elif field_type in ("string", "bytes"):
             # String array
             result = f'  get {name}() {{\n'
             result += f'    const result = [];\n'
@@ -1033,7 +1033,7 @@ class TestJsGen():
         }
         if type_name in type_values:
             return type_values[type_name]
-        if type_name == "string":
+        if type_name in ("string", "bytes"):
             return f'"test_{index}"'
         if field.is_enum:
             return "0"
@@ -1049,7 +1049,7 @@ class TestJsGen():
         if field.is_array:
             if field.size_option is not None:
                 count = min(field.size_option, 3)
-                if type_name == "string":
+                if type_name in ("string", "bytes"):
                     items = [f'"test_{i}"' for i in range(count)]
                     pad = ['""' for _ in range(field.size_option - count)]
                 elif type_name == "bool":
@@ -1065,7 +1065,7 @@ class TestJsGen():
                 result += f"    {prefix}.{var_name} = {arr_literal};\n"
             elif field.max_size is not None:
                 num_elements = min(field.max_size, 3)
-                if type_name == "string":
+                if type_name in ("string", "bytes"):
                     items = [f'"test_{i}"' for i in range(num_elements)]
                 elif type_name == "bool":
                     items = [str((42 + i) % 2) for i in range(num_elements)]
@@ -1076,7 +1076,7 @@ class TestJsGen():
                 arr_literal = "[" + ", ".join(items) + "]"
                 result += f"    {prefix}.{var_name}Count = {num_elements};\n"
                 result += f"    {prefix}.{var_name}Data = {arr_literal};\n"
-        elif type_name == "string":
+        elif type_name in ("string", "bytes"):
             if field.size_option is not None:
                 result += f'    {prefix}.{var_name} = "test_string";\n'
             elif field.max_size is not None:

--- a/src/struct_frame/py_gen.py
+++ b/src/struct_frame/py_gen.py
@@ -870,7 +870,7 @@ class MessagePyGen():
                     result += f'        # Variable string: {f.name}\n'
                     result += f'        str_data = self.{f.name}[:{f.max_size}]\n'
                     result += f'        data += struct.pack("<{count_fmt}", len(str_data))\n'
-                    result += f'        data += struct.pack("<{f.max_size}s", str_data)\n'
+                    result += '        data += struct.pack(f"<{len(str_data)}s", str_data)\n'
             elif f.is_array:
                 if f.field_type in ("string", "bytes"):
                     element_size = f.element_size if f.element_size else 16
@@ -878,15 +878,17 @@ class MessagePyGen():
                         result += f'        # Fixed string array: {f.name}\n'
                         result += f'        for i in range({f.size_option}):\n'
                         result += f'            if i < len(self.{f.name}):\n'
-                        result += f'                data += struct.pack("<{element_size}s", self.{f.name}[i][:{element_size}])\n'
+                        result += f'                item = self.{f.name}[i][: {element_size}]\n'
+                        result += '                data += struct.pack(f"<{len(item)}s", item)\n'
                         result += f'            else:\n'
-                        result += f'                data += struct.pack("<{element_size}s", b"")\n'
+                        result += '                data += struct.pack("<0s", b"")\n'
                     elif f.max_size is not None:
                         count_fmt = "H" if f.max_size > 255 else "B"
                         result += f'        # Bounded string array: {f.name}\n'
                         result += f'        data += struct.pack("<{count_fmt}", min(len(self.{f.name}), {f.max_size}))\n'
                         result += f'        for i in range(min(len(self.{f.name}), {f.max_size})):\n'
-                        result += f'            data += struct.pack("<{element_size}s", self.{f.name}[i][:{element_size}])\n'
+                        result += f'            item = self.{f.name}[i][: {element_size}]\n'
+                        result += '            data += struct.pack(f"<{len(item)}s", item)\n'
                 else:
                     fmt = MessagePyGen.get_struct_format(f)
                     if f.size_option is not None:

--- a/src/struct_frame/py_gen.py
+++ b/src/struct_frame/py_gen.py
@@ -51,6 +51,7 @@ py_type_hints = {
     "uint64": "int",
     "int64": "int",
     "string": "bytes",
+    "bytes": "bytes",   # bytes treated identically to string (same wire format)
 }
 
 
@@ -133,11 +134,11 @@ class FieldPyGen():
         
         # Handle arrays
         if field.is_array:
-            if field.field_type == "string":
+            if field.field_type in ("string", "bytes"):
                 return "List[bytes]"
             else:
                 return f"List[{base_hint}]"
-        elif field.field_type == "string":
+        elif field.field_type in ("string", "bytes"):
             return "bytes"
         else:
             return base_hint
@@ -158,7 +159,7 @@ class FieldPyGen():
                 result += f'  # Fixed array: {field.size_option} elements'
             elif field.max_size is not None:
                 result += f'  # Bounded array: max {field.max_size} elements'
-        elif field.field_type == "string":
+        elif field.field_type in ("string", "bytes"):
             if field.size_option is not None:
                 result += f'  # Fixed string: {field.size_option} bytes'
             elif field.max_size is not None:
@@ -188,7 +189,7 @@ class MessagePyGen():
             base_fmt = py_struct_format[type_name]
         elif field.is_enum:
             base_fmt = "B"  # Enums are uint8
-        elif type_name == "string":
+        elif type_name in ("string", "bytes"):
             # Strings need special handling
             if field.size_option is not None:
                 return f"{field.size_option}s"
@@ -274,7 +275,7 @@ class MessagePyGen():
         
         # Pack regular fields
         for key, f in msg.fields.items():
-            if f.field_type == "string" and not f.is_array:
+            if f.field_type in ("string", "bytes") and not f.is_array:
                 # String field
                 if f.size_option is not None:
                     # Fixed string
@@ -289,7 +290,7 @@ class MessagePyGen():
                     result += f'        data += struct.pack("<{f.max_size}s", str_data)\n'
             elif f.is_array:
                 # Array field
-                if f.field_type == "string":
+                if f.field_type in ("string", "bytes"):
                     # String array
                     if f.size_option is not None:
                         # Fixed string array
@@ -412,7 +413,7 @@ class MessagePyGen():
         result += '        fields = {}\n'
         
         for key, f in msg.fields.items():
-            if f.field_type == "string" and not f.is_array:
+            if f.field_type in ("string", "bytes") and not f.is_array:
                 # String field
                 if f.size_option is not None:
                     # Fixed string
@@ -431,7 +432,7 @@ class MessagePyGen():
                     result += f'        offset += {f.max_size}\n'
             elif f.is_array:
                 # Array field
-                if f.field_type == "string":
+                if f.field_type in ("string", "bytes"):
                     # String array
                     if f.size_option is not None:
                         # Fixed string array
@@ -507,7 +508,6 @@ class MessagePyGen():
                             result += f'                fields["{f.name}"].append(val)\n'
                         else:
                             # Nested messages
-                            type_name = f.field_type
                             result += f'        # Bounded nested message array: {f.name}\n'
                             result += f'        count = struct.unpack_from("<{count_fmt}", data, offset)[0]\n'
                             result += f'        offset += {count_size}\n'
@@ -656,7 +656,7 @@ class MessagePyGen():
                     result += f'        self.{f.name} = [_truncate_float32(v) for v in {f.name}] if {f.name} is not None else []\n'
                 else:
                     result += f'        self.{f.name} = {f.name} if {f.name} is not None else []\n'
-            elif f.field_type == "string":
+            elif f.field_type in ("string", "bytes"):
                 result += f'        self.{f.name} = {f.name} if {f.name} is not None else b""\n'
             elif f.field_type in py_type_hints:
                 if f.field_type == "bool":
@@ -708,11 +708,11 @@ class MessagePyGen():
         result += '        out = {}\n'
         for key, f in msg.fields.items():
             if f.is_array:
-                if f.is_default_type or f.is_enum or f.field_type == "string":
+                if f.is_default_type or f.is_enum or f.field_type in ("string", "bytes"):
                     result += f'        out["{key}"] = self.{key}\n'
                 else:
                     result += f'        out["{key}"] = [item.to_dict(False, False) for item in self.{key}]\n'
-            elif f.is_default_type or f.is_enum or f.field_type == "string":
+            elif f.is_default_type or f.is_enum or f.field_type in ("string", "bytes"):
                 result += f'        out["{key}"] = self.{key}\n'
             else:
                 if getattr(f, 'flatten', False):
@@ -821,12 +821,12 @@ class MessagePyGen():
             if f.is_array and f.max_size is not None:
                 # Variable array
                 type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
-                if f.field_type == "string":
+                if f.field_type in ("string", "bytes"):
                     element_size = f.element_size if f.element_size else 1
                 else:
                     element_size = type_sizes.get(f.field_type, (f.size - 1) // f.max_size)
                 result += f'        size += 1 + (min(len(self.{f.name}), {f.max_size}) * {element_size})  # {f.name}\n'
-            elif f.field_type == "string" and f.max_size is not None:
+            elif f.field_type in ("string", "bytes") and f.max_size is not None:
                 # Variable string
                 result += f'        size += 1 + min(len(self.{f.name}), {f.max_size})  # {f.name}\n'
             else:
@@ -864,41 +864,53 @@ class MessagePyGen():
             if f.is_array and f.max_size is not None:
                 # Variable array
                 type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
-                if f.field_type == "string":
+                if f.field_type in ("string", "bytes"):
                     element_size = f.element_size if f.element_size else 1
                     result += f'        # {f.name}: variable string array\n'
-                    result += f'        count = min(len(self.{f.name}), {f.max_size})\n'
-                    result += f'        data += struct.pack("<B", count)\n'
-                    result += f'        for i in range(count):\n'
-                    result += f'            data += struct.pack("<{element_size}s", self.{f.name}[i][:{element_size}])\n'
+                    result += f'        count = struct.unpack_from("<B", data, offset)[0]\n'
+                    result += f'        offset += 1\n'
+                    result += f'        fields["{f.name}"] = []\n'
+                    result += f'        for i in range(min(count, {f.max_size})):\n'
+                    result += f'            s = struct.unpack_from("<{element_size}s", data, offset)[0]\n'
+                    result += f'            fields["{f.name}"].append(s)\n'
+                    result += f'            offset += {element_size}\n'
                 elif f.is_enum:
                     result += f'        # {f.name}: variable enum array\n'
-                    result += f'        count = min(len(self.{f.name}), {f.max_size})\n'
-                    result += f'        data += struct.pack("<B", count)\n'
-                    result += f'        for i in range(count):\n'
-                    result += f'            data += struct.pack("<B", int(self.{f.name}[i]))\n'
+                    result += f'        count = struct.unpack_from("<B", data, offset)[0]\n'
+                    result += f'        offset += 1\n'
+                    result += f'        fields["{f.name}"] = []\n'
+                    result += f'        for i in range(min(count, {f.max_size})):\n'
+                    result += f'            val = struct.unpack_from("<B", data, offset)[0]\n'
+                    result += f'            offset += 1\n'
+                    result += f'            fields["{f.name}"].append(val)\n'
                 elif f.field_type in type_sizes:
                     element_size = type_sizes[f.field_type]
                     fmt = py_struct_format.get(f.field_type, 'B')
                     result += f'        # {f.name}: variable {f.field_type} array\n'
-                    result += f'        count = min(len(self.{f.name}), {f.max_size})\n'
-                    result += f'        data += struct.pack("<B", count)\n'
-                    result += f'        for i in range(count):\n'
-                    result += f'            data += struct.pack("<{fmt}", self.{f.name}[i])\n'
+                    result += f'        count = struct.unpack_from("<B", data, offset)[0]\n'
+                    result += f'        offset += 1\n'
+                    result += f'        fields["{f.name}"] = []\n'
+                    result += f'        for i in range(min(count, {f.max_size})):\n'
+                    result += f'            val = struct.unpack_from("<{fmt}", data, offset)[0]\n'
+                    result += f'            offset += {element_size}\n'
+                    result += f'            fields["{f.name}"].append(val)\n'
                 else:
                     # Nested message array
                     result += f'        # {f.name}: variable nested message array\n'
-                    result += f'        count = min(len(self.{f.name}), {f.max_size})\n'
-                    result += f'        data += struct.pack("<B", count)\n'
-                    result += f'        for i in range(count):\n'
-                    result += f'            data += self.{f.name}[i].serialize()\n'
-            elif f.field_type == "string" and f.max_size is not None:
+                    result += f'        count = struct.unpack_from("<B", data, offset)[0]\n'
+                    result += f'        offset += 1\n'
+                    result += f'        fields["{f.name}"] = []\n'
+                    result += f'        for i in range(min(count, {f.max_size})):\n'
+                    result += f'            msg = {type_name}._deserialize_fixed(data[offset:offset+{type_name}.MAX_SIZE])\n'
+                    result += f'            fields["{f.name}"].append(msg)\n'
+                    result += f'            offset += {type_name}.MAX_SIZE\n'
+            elif f.field_type in ("string", "bytes") and f.max_size is not None:
                 # Variable string
                 result += f'        # {f.name}: variable string\n'
                 result += f'        str_data = self.{f.name}[:{f.max_size}]\n'
                 result += f'        data += struct.pack("<B", len(str_data))\n'
                 result += f'        data += str_data\n'
-            elif f.field_type == "string" and f.size_option is not None:
+            elif f.field_type in ("string", "bytes") and f.size_option is not None:
                 # Fixed string
                 result += f'        # {f.name}: fixed string\n'
                 result += f'        data += struct.pack("<{f.size_option}s", self.{f.name}[:{f.size_option}])\n'
@@ -906,35 +918,45 @@ class MessagePyGen():
                 # Fixed array (pack as usual)
                 if f.is_enum:
                     result += f'        # {f.name}: fixed enum array\n'
+                    result += f'        fields["{f.name}"] = []\n'
                     result += f'        for i in range({f.size_option}):\n'
-                    result += f'            val = self.{f.name}[i] if i < len(self.{f.name}) else 0\n'
-                    result += f'            data += struct.pack("<B", int(val))\n'
+                    result += f'            val = struct.unpack_from("<B", data, offset)[0]\n'
+                    result += f'            offset += 1\n'
+                    result += f'            fields["{f.name}"].append(val)\n'
                 elif f.field_type in py_struct_format:
                     fmt = py_struct_format[f.field_type]
+                    size = struct_format_sizes[fmt]
                     result += f'        # {f.name}: fixed {f.field_type} array\n'
+                    result += f'        fields["{f.name}"] = []\n'
                     result += f'        for i in range({f.size_option}):\n'
-                    result += f'            val = self.{f.name}[i] if i < len(self.{f.name}) else 0\n'
-                    result += f'            data += struct.pack("<{fmt}", val)\n'
+                    result += f'            val = struct.unpack_from("<{fmt}", data, offset)[0]\n'
+                    result += f'            offset += {size}\n'
+                    result += f'            fields["{f.name}"].append(val)\n'
                 else:
                     # Nested message fixed array
                     type_name = f.field_type
                     result += f'        # {f.name}: fixed nested message array\n'
+                    result += f'        fields["{f.name}"] = []\n'
                     result += f'        for i in range({f.size_option}):\n'
-                    result += f'            if i < len(self.{f.name}):\n'
-                    result += f'                data += self.{f.name}[i].serialize()\n'
-                    result += f'            else:\n'
-                    result += f'                data += {type_name}().serialize()\n'
+                    result += f'            msg = {type_name}._deserialize_fixed(data[offset:offset+{type_name}.MAX_SIZE])\n'
+                    result += f'            fields["{f.name}"].append(msg)\n'
+                    result += f'            offset += {type_name}.MAX_SIZE\n'
             elif f.field_type in py_struct_format:
                 fmt = py_struct_format[f.field_type]
+                size = struct_format_sizes[fmt]
                 result += f'        # {f.name}: {f.field_type}\n'
-                result += f'        data += struct.pack("<{fmt}", self.{f.name})\n'
+                result += f'        fields["{f.name}"] = struct.unpack_from("<{fmt}", data, offset)[0]\n'
+                result += f'        offset += {size}\n'
             elif f.is_enum:
                 result += f'        # {f.name}: enum\n'
-                result += f'        data += struct.pack("<B", int(self.{f.name}))\n'
+                result += f'        fields["{f.name}"] = struct.unpack_from("<B", data, offset)[0]\n'
+                result += f'        offset += 1\n'
             else:
                 # Nested message
+                type_name = f.field_type
                 result += f'        # {f.name}: nested message\n'
-                result += f'        data += self.{f.name}.serialize()\n'
+                result += f'        fields["{f.name}"] = {type_name}._deserialize_fixed(data[offset:offset+{type_name}.MAX_SIZE])\n'
+                result += f'        offset += {type_name}.MAX_SIZE\n'
         
         # Oneofs: write discriminator + union payload (or length-prefix + variant bytes for variable oneof)
         for oneof_name, oneof in msg.oneofs.items():
@@ -994,7 +1016,7 @@ class MessagePyGen():
             if f.is_array and f.max_size is not None:
                 # Variable array
                 type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
-                if f.field_type == "string":
+                if f.field_type in ("string", "bytes"):
                     element_size = f.element_size if f.element_size else 1
                     result += f'        # {f.name}: variable string array\n'
                     result += f'        count = struct.unpack_from("<B", data, offset)[0]\n'
@@ -1036,7 +1058,7 @@ class MessagePyGen():
                     result += f'            msg = {type_name}._deserialize_fixed(data[offset:offset+{type_name}.MAX_SIZE])\n'
                     result += f'            fields["{f.name}"].append(msg)\n'
                     result += f'            offset += {type_name}.MAX_SIZE\n'
-            elif f.field_type == "string" and f.max_size is not None:
+            elif f.field_type in ("string", "bytes") and f.max_size is not None:
                 # Variable string
                 result += f'        # {f.name}: variable string\n'
                 result += f'        str_len = struct.unpack_from("<B", data, offset)[0]\n'
@@ -1044,7 +1066,7 @@ class MessagePyGen():
                 result += f'        str_len = min(str_len, {f.max_size})\n'
                 result += f'        fields["{f.name}"] = data[offset:offset+str_len]\n'
                 result += f'        offset += str_len\n'
-            elif f.field_type == "string" and f.size_option is not None:
+            elif f.field_type in ("string", "bytes") and f.size_option is not None:
                 # Fixed string
                 result += f'        # {f.name}: fixed string\n'
                 result += f'        fields["{f.name}"] = struct.unpack_from("<{f.size_option}s", data, offset)[0]\n'
@@ -1179,7 +1201,7 @@ class MessagePyGen():
         field_inits = []
         for f_name, f in msg.fields.items():
             type_hint = FieldPyGen.get_type_hint(f)
-            if f.is_array or f.field_type == "string":
+            if f.is_array or f.field_type in ("string", "bytes"):
                 field_params.append(f'{f.name}: {type_hint} = None')
             else:
                 field_params.append(f'{f.name}: {type_hint}')
@@ -1512,7 +1534,7 @@ class TestPyGen():
         
         if type_name in type_values:
             return type_values[type_name]
-        elif type_name == "string":
+        elif type_name in ("string", "bytes"):
             return f'b"test_{index}"'
         elif field.is_enum:
             # Return 0 as a safe default for enums
@@ -1535,7 +1557,7 @@ class TestPyGen():
             if field.size_option is not None:
                 # Fixed array - generated as a Python list, so initialise it before indexing
                 count = min(field.size_option, 3)
-                if type_name == "string":
+                if type_name in ("string", "bytes"):
                     items = ", ".join(f'b"test_{i}"' for i in range(count))
                 else:
                     items = ", ".join(TestPyGen._get_dummy_value(field, i) for i in range(count))
@@ -1543,7 +1565,7 @@ class TestPyGen():
                 # the message serialiser emitted by FilePyGen, which always
                 # iterates the full ``size_option`` count, finds a valid value
                 # at every index instead of raising IndexError.
-                if type_name == "string":
+                if type_name in ("string", "bytes"):
                     pad = ", ".join('b""' for _ in range(field.size_option - count))
                 else:
                     pad_val = "0" if field.is_enum or type_name != "bool" else "False"
@@ -1555,12 +1577,12 @@ class TestPyGen():
                 num_elements = min(field.max_size, 3)
                 result += f"    {prefix}.{var_name} = []\n"
                 for i in range(num_elements):
-                    if type_name == "string":
+                    if type_name in ("string", "bytes"):
                         result += f'    {prefix}.{var_name}.append(b"test_{i}")\n'
                     else:
                         result += f"    {prefix}.{var_name}.append({TestPyGen._get_dummy_value(field, i)})\n"
         # Handle regular strings
-        elif type_name == "string":
+        elif type_name in ("string", "bytes"):
             result += f'    {prefix}.{var_name} = b"test_string"\n'
         else:
             # Regular field

--- a/src/struct_frame/py_gen.py
+++ b/src/struct_frame/py_gen.py
@@ -859,115 +859,87 @@ class MessagePyGen():
         result += '\n    def _serialize_variable(self) -> bytes:\n'
         result += '        """Serialize message using variable-length encoding (only serializes used bytes)."""\n'
         result += '        data = b""\n'
-        
+
         for key, f in msg.fields.items():
-            if f.is_array and f.max_size is not None:
-                # Variable array
-                type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
+            if f.field_type in ("string", "bytes") and not f.is_array:
+                if f.size_option is not None:
+                    result += f'        # Fixed string: {f.name}\n'
+                    result += f'        data += struct.pack("<{f.size_option}s", self.{f.name}[:{f.size_option}])\n'
+                elif f.max_size is not None:
+                    count_fmt = "H" if f.max_size > 255 else "B"
+                    result += f'        # Variable string: {f.name}\n'
+                    result += f'        str_data = self.{f.name}[:{f.max_size}]\n'
+                    result += f'        data += struct.pack("<{count_fmt}", len(str_data))\n'
+                    result += f'        data += struct.pack("<{f.max_size}s", str_data)\n'
+            elif f.is_array:
                 if f.field_type in ("string", "bytes"):
-                    element_size = f.element_size if f.element_size else 1
-                    result += f'        # {f.name}: variable string array\n'
-                    result += f'        count = struct.unpack_from("<B", data, offset)[0]\n'
-                    result += f'        offset += 1\n'
-                    result += f'        fields["{f.name}"] = []\n'
-                    result += f'        for i in range(min(count, {f.max_size})):\n'
-                    result += f'            s = struct.unpack_from("<{element_size}s", data, offset)[0]\n'
-                    result += f'            fields["{f.name}"].append(s)\n'
-                    result += f'            offset += {element_size}\n'
-                elif f.is_enum:
-                    result += f'        # {f.name}: variable enum array\n'
-                    result += f'        count = struct.unpack_from("<B", data, offset)[0]\n'
-                    result += f'        offset += 1\n'
-                    result += f'        fields["{f.name}"] = []\n'
-                    result += f'        for i in range(min(count, {f.max_size})):\n'
-                    result += f'            val = struct.unpack_from("<B", data, offset)[0]\n'
-                    result += f'            offset += 1\n'
-                    result += f'            fields["{f.name}"].append(val)\n'
-                elif f.field_type in type_sizes:
-                    element_size = type_sizes[f.field_type]
-                    fmt = py_struct_format.get(f.field_type, 'B')
-                    result += f'        # {f.name}: variable {f.field_type} array\n'
-                    result += f'        count = struct.unpack_from("<B", data, offset)[0]\n'
-                    result += f'        offset += 1\n'
-                    result += f'        fields["{f.name}"] = []\n'
-                    result += f'        for i in range(min(count, {f.max_size})):\n'
-                    result += f'            val = struct.unpack_from("<{fmt}", data, offset)[0]\n'
-                    result += f'            offset += {element_size}\n'
-                    result += f'            fields["{f.name}"].append(val)\n'
+                    element_size = f.element_size if f.element_size else 16
+                    if f.size_option is not None:
+                        result += f'        # Fixed string array: {f.name}\n'
+                        result += f'        for i in range({f.size_option}):\n'
+                        result += f'            if i < len(self.{f.name}):\n'
+                        result += f'                data += struct.pack("<{element_size}s", self.{f.name}[i][:{element_size}])\n'
+                        result += f'            else:\n'
+                        result += f'                data += struct.pack("<{element_size}s", b"")\n'
+                    elif f.max_size is not None:
+                        count_fmt = "H" if f.max_size > 255 else "B"
+                        result += f'        # Bounded string array: {f.name}\n'
+                        result += f'        data += struct.pack("<{count_fmt}", min(len(self.{f.name}), {f.max_size}))\n'
+                        result += f'        for i in range(min(len(self.{f.name}), {f.max_size})):\n'
+                        result += f'            data += struct.pack("<{element_size}s", self.{f.name}[i][:{element_size}])\n'
                 else:
-                    # Nested message array
-                    result += f'        # {f.name}: variable nested message array\n'
-                    result += f'        count = struct.unpack_from("<B", data, offset)[0]\n'
-                    result += f'        offset += 1\n'
-                    result += f'        fields["{f.name}"] = []\n'
-                    result += f'        for i in range(min(count, {f.max_size})):\n'
-                    result += f'            msg = {type_name}._deserialize_fixed(data[offset:offset+{type_name}.MAX_SIZE])\n'
-                    result += f'            fields["{f.name}"].append(msg)\n'
-                    result += f'            offset += {type_name}.MAX_SIZE\n'
-            elif f.field_type in ("string", "bytes") and f.max_size is not None:
-                # Variable string
-                result += f'        # {f.name}: variable string\n'
-                result += f'        str_data = self.{f.name}[:{f.max_size}]\n'
-                result += f'        data += struct.pack("<B", len(str_data))\n'
-                result += f'        data += str_data\n'
-            elif f.field_type in ("string", "bytes") and f.size_option is not None:
-                # Fixed string
-                result += f'        # {f.name}: fixed string\n'
-                result += f'        data += struct.pack("<{f.size_option}s", self.{f.name}[:{f.size_option}])\n'
-            elif f.is_array and f.size_option is not None:
-                # Fixed array (pack as usual)
-                if f.is_enum:
-                    result += f'        # {f.name}: fixed enum array\n'
-                    result += f'        fields["{f.name}"] = []\n'
-                    result += f'        for i in range({f.size_option}):\n'
-                    result += f'            val = struct.unpack_from("<B", data, offset)[0]\n'
-                    result += f'            offset += 1\n'
-                    result += f'            fields["{f.name}"].append(val)\n'
-                elif f.field_type in py_struct_format:
-                    fmt = py_struct_format[f.field_type]
-                    size = struct_format_sizes[fmt]
-                    result += f'        # {f.name}: fixed {f.field_type} array\n'
-                    result += f'        fields["{f.name}"] = []\n'
-                    result += f'        for i in range({f.size_option}):\n'
-                    result += f'            val = struct.unpack_from("<{fmt}", data, offset)[0]\n'
-                    result += f'            offset += {size}\n'
-                    result += f'            fields["{f.name}"].append(val)\n'
-                else:
-                    # Nested message fixed array
-                    type_name = f.field_type
-                    result += f'        # {f.name}: fixed nested message array\n'
-                    result += f'        fields["{f.name}"] = []\n'
-                    result += f'        for i in range({f.size_option}):\n'
-                    result += f'            msg = {type_name}._deserialize_fixed(data[offset:offset+{type_name}.MAX_SIZE])\n'
-                    result += f'            fields["{f.name}"].append(msg)\n'
-                    result += f'            offset += {type_name}.MAX_SIZE\n'
-            elif f.field_type in py_struct_format:
-                fmt = py_struct_format[f.field_type]
-                size = struct_format_sizes[fmt]
-                result += f'        # {f.name}: {f.field_type}\n'
-                result += f'        fields["{f.name}"] = struct.unpack_from("<{fmt}", data, offset)[0]\n'
-                result += f'        offset += {size}\n'
-            elif f.is_enum:
-                result += f'        # {f.name}: enum\n'
-                result += f'        fields["{f.name}"] = struct.unpack_from("<B", data, offset)[0]\n'
-                result += f'        offset += 1\n'
+                    fmt = MessagePyGen.get_struct_format(f)
+                    if f.size_option is not None:
+                        if fmt:
+                            result += f'        # Fixed array: {f.name}\n'
+                            result += f'        for i in range({f.size_option}):\n'
+                            result += f'            val = self.{f.name}[i] if i < len(self.{f.name}) else 0\n'
+                            if f.is_enum:
+                                result += f'            data += struct.pack("<B", int(val))\n'
+                            else:
+                                base_fmt = py_struct_format[f.field_type]
+                                result += f'            data += struct.pack("<{base_fmt}", val)\n'
+                        else:
+                            type_name = f.field_type
+                            result += f'        # Fixed nested message array: {f.name}\n'
+                            result += f'        for i in range({f.size_option}):\n'
+                            result += f'            if i < len(self.{f.name}):\n'
+                            result += f'                data += self.{f.name}[i].serialize()\n'
+                            result += f'            else:\n'
+                            result += f'                data += {type_name}().serialize()\n'
+                    elif f.max_size is not None:
+                        count_fmt = "H" if f.max_size > 255 else "B"
+                        if f.is_default_type or f.is_enum:
+                            result += f'        # Bounded array: {f.name}\n'
+                            result += f'        data += struct.pack("<{count_fmt}", min(len(self.{f.name}), {f.max_size}))\n'
+                            result += f'        for i in range(min(len(self.{f.name}), {f.max_size})):\n'
+                            result += f'            val = self.{f.name}[i]\n'
+                            if f.is_enum:
+                                result += f'            data += struct.pack("<B", int(val))\n'
+                            else:
+                                base_fmt = py_struct_format[f.field_type]
+                                result += f'            data += struct.pack("<{base_fmt}", val)\n'
+                        else:
+                            result += f'        # Bounded nested message array: {f.name}\n'
+                            result += f'        data += struct.pack("<{count_fmt}", min(len(self.{f.name}), {f.max_size}))\n'
+                            result += f'        for i in range(min(len(self.{f.name}), {f.max_size})):\n'
+                            result += f'            data += self.{f.name}[i].serialize()\n'
             else:
-                # Nested message
-                type_name = f.field_type
-                result += f'        # {f.name}: nested message\n'
-                result += f'        fields["{f.name}"] = {type_name}._deserialize_fixed(data[offset:offset+{type_name}.MAX_SIZE])\n'
-                result += f'        offset += {type_name}.MAX_SIZE\n'
-        
-        # Oneofs: write discriminator + union payload (or length-prefix + variant bytes for variable oneof)
+                fmt = MessagePyGen.get_struct_format(f)
+                if fmt:
+                    result += f'        data += struct.pack("<{fmt}", self.{f.name})\n'
+                else:
+                    result += f'        data += self.{f.name}.serialize()\n'
+
         for oneof_name, oneof in msg.oneofs.items():
             if oneof.auto_discriminator:
                 if oneof.discriminator_type == "msgid":
-                    result += f'        # Oneof {oneof_name} discriminator (uint16 - message ID)\n'
+                    result += f'        # Oneof {oneof_name} auto-discriminator (uint16 - message ID)\n'
                     result += f'        if self.{oneof_name}_which is not None:\n'
                     result += f'            data += struct.pack("<H", self.{oneof_name}[self.{oneof_name}_which].__class__.msg_id)\n'
                     result += f'        else:\n'
                     result += f'            data += struct.pack("<H", 0)\n'
-                else:  # field_order
+                else:
                     result += f'        # Oneof {oneof_name} discriminator (uint8 - field order, 1-based)\n'
                     field_order_map = {field_name: idx + 1 for idx, field_name in enumerate(oneof.field_order)}
                     result += f'        _field_order_map = {field_order_map}\n'
@@ -1002,7 +974,7 @@ class MessagePyGen():
                 result += f'            union_data = self.{oneof_name}[self.{oneof_name}_which].serialize()\n'
                 result += f'        union_data = union_data.ljust({oneof.size}, b"\\x00")\n'
                 result += f'        data += union_data\n'
-        
+
         result += '        return data\n'
         
         # Generate _deserialize_variable class method (internal method)

--- a/src/struct_frame/rust_gen.py
+++ b/src/struct_frame/rust_gen.py
@@ -7,7 +7,7 @@ This module generates Rust code for struct serialization with explicit
 pack/unpack methods for binary compatibility across platforms.
 """
 
-from struct_frame import version, NamingStyleC, camel_to_snake_case, pascal_case, build_enum_leading_comments, build_enum_values
+from struct_frame import version, NamingStyleC, camel_to_snake_case, pascal_case, build_enum_leading_comments, build_enum_values, normalize_bytes_type
 import os
 import time
 
@@ -27,6 +27,7 @@ rust_types = {
     "uint64": "u64",
     "int64": "i64",
     "string": "u8",  # strings are byte arrays in Rust
+    "bytes": "u8",   # bytes fields are byte arrays in Rust (same wire format as string)
 }
 
 # Rust reserved keywords that need escaping with r# prefix
@@ -45,6 +46,11 @@ def _escape_rust_field_name(name):
     if name in RUST_KEYWORDS:
         return f'r#{name}'
     return name
+
+def _normalize_bytes_type(type_name):
+    """Normalize 'bytes' to 'string' since they share the same wire format
+    and Rust representation ([u8; N] byte arrays)."""
+    return normalize_bytes_type(type_name)
 
 # Byte sizes for each proto type
 rust_type_sizes = {
@@ -199,7 +205,7 @@ def _get_field_type(field):
 def _generate_field_decl(field):
     """Generate a Rust struct field declaration."""
     var_name = _escape_rust_field_name(field.name)
-    type_name = field.field_type
+    type_name = _normalize_bytes_type(field.field_type)
 
     if field.is_array:
         if type_name == "string":
@@ -238,7 +244,7 @@ def _generate_pack_field(field, indent='        ', variable=False):
     always packs max_size elements (fixed-size encoding).
     """
     var_name = _escape_rust_field_name(field.name)
-    type_name = field.field_type
+    type_name = _normalize_bytes_type(field.field_type)
     lines = []
 
     if field.is_array:
@@ -372,7 +378,7 @@ def _generate_unpack_field(field, indent='        ', variable=False):
     always reads max_size elements.
     """
     var_name = _escape_rust_field_name(field.name)
-    type_name = field.field_type
+    type_name = _normalize_bytes_type(field.field_type)
     lines = []
 
     if field.is_array:
@@ -569,7 +575,7 @@ def _large_array_size(field):
             return field.size_option
         if field.max_size is not None and field.max_size > 32:
             return field.max_size
-    if field.field_type == "string":
+    if field.field_type in ("string", "bytes"):
         if field.size_option is not None and field.size_option > 32:
             return field.size_option
         if field.max_size is not None and field.max_size > 32:
@@ -582,8 +588,8 @@ def _needs_manual_default(msg):
     for field in msg.fields.values():
         if _large_array_size(field) > 0:
             return True
-        # Non-array string fields with large max_size or size_option
-        if field.field_type == "string" and not field.is_array:
+        # Non-array string/bytes fields with large max_size or size_option
+        if field.field_type in ("string", "bytes") and not field.is_array:
             if field.size_option is not None and field.size_option > 32:
                 return True
             if field.max_size is not None and field.max_size > 32:
@@ -612,7 +618,7 @@ def _generate_default_impl(msg, struct_name):
     result += '        Self {\n'
     for field in msg.fields.values():
         var_name = _escape_rust_field_name(field.name)
-        type_name = field.field_type
+        type_name = _normalize_bytes_type(field.field_type)
         if field.is_array:
             if field.size_option is not None:
                 if type_name == "string":
@@ -927,13 +933,13 @@ class MessageRustGen():
                         min_size += 2 if field.max_size > 255 else 1  # just the count
                     elif field.size_option is not None:
                         ts = rust_type_sizes.get(field.field_type, 1)
-                        elem_size = field.element_size if (field.field_type == "string" and field.element_size) else ts
-                        if field.field_type == "string":
+                        elem_size = field.element_size if (field.field_type in ("string", "bytes") and field.element_size) else ts
+                        if field.field_type in ("string", "bytes"):
                             elem_size = field.element_size if field.element_size else 16
                         min_size += field.size_option * elem_size
                     else:
                         min_size += field.size if field.size else 0
-                elif field.field_type == "string":
+                elif field.field_type in ("string", "bytes"):
                     if field.max_size is not None and field.size_option is None:
                         min_size += 2 if field.max_size > 255 else 1  # just the length
                     elif field.size_option is not None:
@@ -1033,13 +1039,6 @@ class MessageRustGen():
             result += f'}}\n\n'
 
         return result
-
-
-class FileCSharpGen():
-    """Placeholder to avoid import errors from tests that reference this."""
-    pass
-
-
 class FileRustGen():
     """Generator for Rust files from proto definitions."""
 
@@ -1251,7 +1250,7 @@ class TestRustGen():
         accompanying ``_count``/``_length`` field.
         """
         var_name = _escape_rust_field_name(field.name)
-        type_name = field.field_type
+        type_name = _normalize_bytes_type(field.field_type)
         result = ""
 
         if field.is_array:

--- a/src/struct_frame/ts_gen.py
+++ b/src/struct_frame/ts_gen.py
@@ -355,7 +355,7 @@ class MessageTsClassGen():
         for f_name, f in msg.fields.items():
             # Lookup type annotation once and reuse
             base_ts_type = TS_TYPE_ANNOTATIONS.get(f.field_type, 'number')
-            if f.field_type == "string":
+            if f.field_type in ("string", "bytes"):
                 ts_type = "string"
             elif f.is_array:
                 ts_type = f'{base_ts_type}[]'
@@ -464,12 +464,12 @@ class MessageTsClassGen():
                 # Variable array - TypeScript uses name_count
                 type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
                 count_size = 2 if field.max_size > 255 else 1
-                if field.field_type == "string":
+                if field.field_type in ("string", "bytes"):
                     element_size = field.element_size if field.element_size else 1
                 else:
                     element_size = type_sizes.get(field.field_type, (field.size - count_size) // field.max_size)
                 result += f'    size += {count_size} + (this.{name}Count * {element_size}); // {name}\n'
-            elif field.field_type == "string" and field.max_size is not None:
+            elif field.field_type in ("string", "bytes") and field.max_size is not None:
                 # Variable string - TypeScript uses name_length
                 length_size = 2 if field.max_size > 255 else 1
                 result += f'    size += {length_size} + this.{name}Length; // {name}\n'
@@ -538,7 +538,7 @@ class MessageTsClassGen():
             if field.is_array and field.max_size is not None:
                 # Variable array - TypeScript uses name_count and name_data
                 type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
-                if field_type == "string":
+                if field_type in ("string", "bytes"):
                     element_size = field.element_size if field.element_size else 1
                 else:
                     element_size = type_sizes.get(field_type, (field.size - 1) // field.max_size)
@@ -554,7 +554,7 @@ class MessageTsClassGen():
                     result += f'      nested._buffer.copy(buffer, offset);\n'
                     result += f'      offset += {element_size};\n'
                     result += f'    }}\n'
-                elif field_type == "string":
+                elif field_type in ("string", "bytes"):
                     result += f'    for (let i = 0; i < {name}Count; i++) {{\n'
                     result += f'      const str = this.{name}Data[i] || \'\';\n'
                     result += f'      buffer.write(str.slice(0, {element_size}), offset);\n'
@@ -575,7 +575,7 @@ class MessageTsClassGen():
                     result += f'      buffer.{write_method_name}(this.{name}Data[i], offset);\n'
                     result += f'      offset += {element_size};\n'
                     result += f'    }}\n'
-            elif field_type == "string" and field.max_size is not None:
+            elif field_type in ("string", "bytes") and field.max_size is not None:
                 # Variable string - copy from internal buffer (string is stored there)
                 max_len = field.max_size
                 result += f'    // {name}: variable string\n'
@@ -653,7 +653,7 @@ class MessageTsClassGen():
             if field.is_array and field.max_size is not None:
                 # Variable array
                 type_sizes = {"uint8": 1, "int8": 1, "uint16": 2, "int16": 2, "uint32": 4, "int32": 4, "uint64": 8, "int64": 8, "float": 4, "double": 8, "bool": 1}
-                if field_type == "string":
+                if field_type in ("string", "bytes"):
                     element_size = field.element_size if field.element_size else 1
                 else:
                     element_size = type_sizes.get(field_type, (field.size - 1) // field.max_size)
@@ -670,7 +670,7 @@ class MessageTsClassGen():
                     result += f'      buffer.copy(msg._buffer, {msg_offset + 1} + i * {element_size}, offset, offset + {element_size});\n'
                     result += f'      offset += {element_size};\n'
                     result += f'    }}\n'
-                elif field_type == "string":
+                elif field_type in ("string", "bytes"):
                     result += f'    // Write count to internal buffer\n'
                     result += f'    msg._buffer.writeUInt8({name}Count, {msg_offset});\n'
                     result += f'    for (let i = 0; i < {name}Count; i++) {{\n'
@@ -685,7 +685,7 @@ class MessageTsClassGen():
                     result += f'      buffer.copy(msg._buffer, {msg_offset + 1} + i * {element_size}, offset, offset + {element_size});\n'
                     result += f'      offset += {element_size};\n'
                     result += f'    }}\n'
-            elif field_type == "string" and field.max_size is not None:
+            elif field_type in ("string", "bytes") and field.max_size is not None:
                 # Variable string
                 max_len = field.max_size
                 result += f'    // {name}: variable string\n'
@@ -821,7 +821,7 @@ class MessageTsClassGen():
             if field_info.is_array or field_info.is_nested:
                 # Arrays and nested structs: delegate to getter
                 result += f'      {name}: this.{name},\n'
-            elif field_type == "string":
+            elif field_type in ("string", "bytes"):
                 # Strings: delegate to wrapper (UTF-8 decode cannot be trivially inlined)
                 size = field_info.element_size or field_info.size
                 result += f'      {name}: this._readString({offset}, {size}),\n'
@@ -844,14 +844,14 @@ class MessageTsClassGen():
         if field_info.is_array:
             if field_info.is_nested:
                 return f'({field_info.nested_type} | Record<string, unknown>)[]'
-            elif field_type == "string":
+            elif field_type in ("string", "bytes"):
                 return 'string[]'
             else:
                 if field_info.is_enum:
                     field_type = "uint8"
                 ts_elem_type = TS_ARRAY_TYPE_ANNOTATIONS.get(field_type, "number")
                 return f'{ts_elem_type}[]'
-        elif field_type == "string":
+        elif field_type in ("string", "bytes"):
             return 'string'
         else:
             if field_info.is_enum:
@@ -872,7 +872,7 @@ class MessageTsClassGen():
         
         if field_info.is_array:
             result += MessageTsClassGen._generate_array_accessors(field_info)
-        elif field_type == "string":
+        elif field_type in ("string", "bytes"):
             result += MessageTsClassGen._generate_string_accessors(field_info)
         elif field_info.is_enum or field_type in TYPE_SIZES:
             result += MessageTsClassGen._generate_primitive_accessors(field_info)
@@ -949,7 +949,7 @@ class MessageTsClassGen():
             result += f'  set {name}(value: ({nested_type} | Record<string, unknown>)[]) {{\n'
             result += f'    this._writeStructArray({offset}, {length}, {elem_size}, value, {nested_type});\n'
             result += f'  }}\n\n'
-        elif field_type == "string":
+        elif field_type in ("string", "bytes"):
             # String array using struct array internally (for fixed strings)
             # This is a special case handled by StructArray
             result = f'  get {name}(): string[] {{\n'
@@ -1140,7 +1140,7 @@ class TestTsGen():
         }
         if type_name in type_values:
             return type_values[type_name]
-        if type_name == "string":
+        if type_name in ("string", "bytes"):
             return f'"test_{index}"'
         if field.is_enum:
             return "0"
@@ -1158,7 +1158,7 @@ class TestTsGen():
         if field.is_array:
             if field.size_option is not None:
                 count = min(field.size_option, 3)
-                if type_name == "string":
+                if type_name in ("string", "bytes"):
                     items = [f'"test_{i}"' for i in range(count)]
                     pad = ['""' for _ in range(field.size_option - count)]
                 elif type_name == "bool":
@@ -1176,7 +1176,7 @@ class TestTsGen():
                 result += f"    {prefix}.{var_name} = {arr_literal};\n"
             elif field.max_size is not None:
                 num_elements = min(field.max_size, 3)
-                if type_name == "string":
+                if type_name in ("string", "bytes"):
                     items = [f'"test_{i}"' for i in range(num_elements)]
                 elif type_name == "bool":
                     items = [str((42 + i) % 2) for i in range(num_elements)]
@@ -1187,7 +1187,7 @@ class TestTsGen():
                 arr_literal = "[" + ", ".join(items) + "]"
                 result += f"    {prefix}.{var_name}Count = {num_elements};\n"
                 result += f"    {prefix}.{var_name}Data = {arr_literal};\n"
-        elif type_name == "string":
+        elif type_name in ("string", "bytes"):
             if field.size_option is not None:
                 result += f'    {prefix}.{var_name} = "test_string";\n'
             elif field.max_size is not None:

--- a/src/struct_frame/ts_js_base.py
+++ b/src/struct_frame/ts_js_base.py
@@ -33,6 +33,7 @@ common_types = {
     "int64":    'BigInt64LE',
     "uint64":   'BigUInt64LE',
     "string":   'String',
+    "bytes":    'String',     # bytes treated identically to string (same wire format)
 }
 
 # TypeScript type mappings for array declarations (TypeScript only)
@@ -49,6 +50,7 @@ ts_array_types = {
     "uint64":   'bigint',
     "int64":    'bigint',
     "string":   'string',
+    "bytes":    'string',     # bytes treated identically to string
 }
 
 # Common typed array methods for array fields
@@ -66,6 +68,7 @@ common_typed_array_methods = {
     "int64":    'BigInt64Array',
     "uint64":   'BigUInt64Array',
     "string":   'StructArray',  # String arrays use StructArray
+    "bytes":    'StructArray',  # bytes arrays treated identically to string arrays
 }
 
 
@@ -145,7 +148,7 @@ class BaseFieldGen:
 
         # Handle arrays
         if field.is_array:
-            if field.field_type == "string":
+            if field.field_type in ("string", "bytes"):
                 result = BaseFieldGen._generate_string_array(field, var_name)
             else:
                 base_type, array_method = BaseFieldGen._resolve_array_type(
@@ -153,7 +156,7 @@ class BaseFieldGen:
                 result = BaseFieldGen._generate_typed_array(field, var_name, base_type, array_method)
         else:
             # Non-array fields
-            if field.field_type == "string":
+            if field.field_type in ("string", "bytes"):
                 if hasattr(field, 'size_option') and field.size_option is not None:
                     result += '    // Fixed string: exactly %d chars\n' % field.size_option
                     result += "    .String('%s', %d)" % (var_name, field.size_option)
@@ -258,6 +261,7 @@ TS_TYPE_ANNOTATIONS = {
     "double": "number",
     "bool": "boolean",
     "string": "string",
+    "bytes": "string",     # bytes treated identically to string
 }
 
 # TypeScript type annotations for array elements
@@ -275,6 +279,7 @@ TS_ARRAY_TYPE_ANNOTATIONS = {
     "double": "number",
     "bool": "number",  # Boolean arrays stored as UInt8Array return number[]
     "string": "string",
+    "bytes": "string",     # bytes treated identically to string
 }
 
 # Read method names for MessageBase helper methods
@@ -415,7 +420,7 @@ def calculate_field_layout(msg, package, packages):
         
         if field.is_array:
             # Array field
-            if field_type == "string":
+            if field_type in ("string", "bytes"):
                 # String array
                 if field.size_option is not None:
                     # Fixed string array
@@ -526,7 +531,7 @@ def calculate_field_layout(msg, package, packages):
                         is_variable=True
                     ))
                     offset += total_data_size
-        elif field_type == "string":
+        elif field_type in ("string", "bytes"):
             # Non-array string
             if field.size_option is not None:
                 # Fixed string

--- a/tests/api_stability/crates/check_api.py
+++ b/tests/api_stability/crates/check_api.py
@@ -1,7 +1,62 @@
 #!/usr/bin/env python3
+"""Check Rust crate public API stability against a baseline snapshot.
+
+If no baseline exists, the test is skipped. If a baseline exists, the
+generated Rust source files are scanned for ``pub`` items and compared
+to the baseline.  Removed items cause a failure; new items are reported
+as non-breaking additions.
+"""
 from pathlib import Path
-baseline = Path(__file__).with_name('public-api.txt')
-if not baseline.exists():
-    print('crates.io API stability scaffold: no public-api.txt yet; skipping.')
-    raise SystemExit(0)
-print('crates.io API stability scaffold: compare cargo-public-api output to public-api.txt here.')
+import re, sys
+
+ROOT = Path(__file__).resolve().parents[2]  # tests/
+GENERATED_DIR = ROOT / 'generated' / 'rust'
+BASELINE = Path(__file__).with_name('public-api.txt')
+
+PUB_RE = re.compile(
+    r'pub\s+(?:const|static|fn|struct|enum|trait|type|mod)\s+(\w+)'
+)
+
+def collect_public_items() -> list[str]:
+    items = []
+    if not GENERATED_DIR.exists():
+        print(f'Generated directory not found: {GENERATED_DIR}', file=sys.stderr)
+        sys.exit(1)
+    for f in sorted(GENERATED_DIR.glob('*.rs')):
+        if f.name == 'lib.rs' or f.suffix == '.rs' and '.structframe.' in f.name:
+            for i, line in enumerate(f.read_text().splitlines(), 1):
+                m = PUB_RE.match(line.strip())
+                if m:
+                    items.append(f'{f.name}:{m.group(1)}')
+    return sorted(items)
+
+def main() -> int:
+    if not BASELINE.exists():
+        print('crates.io API stability: no public-api.txt yet; skipping.')
+        return 0
+
+    current = collect_public_items()
+    expected = [
+        l.strip() for l in BASELINE.read_text().splitlines()
+        if l.strip() and not l.startswith('#')
+    ]
+
+    removed = [e for e in expected if e not in current]
+    added = [c for c in current if c not in expected]
+
+    if removed:
+        print('crates.io API stability: BREAKING CHANGES detected:', file=sys.stderr)
+        for r in removed:
+            print(f'  REMOVED: {r}', file=sys.stderr)
+        return 1
+
+    if added:
+        print('crates.io API stability: new items added (non-breaking):')
+        for a in added:
+            print(f'  ADDED: {a}')
+
+    print(f'crates.io API stability: compatible ({len(current)} items checked).')
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/api_stability/npm/check_api.js
+++ b/tests/api_stability/npm/check_api.js
@@ -1,8 +1,54 @@
 const fs = require('fs');
 const path = require('path');
+
 const baseline = path.join(__dirname, 'baseline.d.ts');
+const generatedDir = path.join(__dirname, '..', '..', 'generated', 'ts');
+
 if (!fs.existsSync(baseline)) {
-  console.log('npm API stability scaffold: no baseline.d.ts yet; skipping.');
+  console.log('npm API stability: no baseline.d.ts yet; skipping.');
   process.exit(0);
 }
-console.log('npm API stability scaffold: compare generated declarations to baseline.d.ts here.');
+
+// Collect all .ts files from the generated directory, excluding test files
+function collectGeneratedDeclarations(dir) {
+  const lines = [];
+  if (!fs.existsSync(dir)) {
+    console.error(`Generated directory not found: ${dir}`);
+    process.exit(1);
+  }
+  for (const file of fs.readdirSync(dir).sort()) {
+    if (file.endsWith('.structframe.ts') || file === 'index.ts') {
+      const content = fs.readFileSync(path.join(dir, file), 'utf8');
+      // Extract exported names (types, interfaces, classes, enums, const, functions)
+      const exportMatches = content.matchAll(
+        /export\s+(?:const|let|var|function|class|interface|type|enum)\s+(\w+)/g
+      );
+      for (const m of exportMatches) {
+        lines.push(`${file}:${m[1]}`);
+      }
+    }
+  }
+  return lines.sort();
+}
+
+const current = collectGeneratedDeclarations(generatedDir);
+const expected = fs.readFileSync(baseline, 'utf8')
+  .split('\n')
+  .filter(l => l.trim() && !l.startsWith('#'));
+
+const removed = expected.filter(e => !current.includes(e));
+const added = current.filter(e => !expected.includes(e));
+
+if (removed.length > 0) {
+  console.error('npm API stability: BREAKING CHANGES detected:');
+  for (const r of removed) console.error(`  REMOVED: ${r}`);
+  process.exit(1);
+}
+
+if (added.length > 0) {
+  console.log('npm API stability: new exports added (non-breaking):');
+  for (const a of added) console.log(`  ADDED: ${a}`);
+}
+
+console.log(`npm API stability: compatible (${current.length} exports checked).`);
+process.exit(0);

--- a/tests/api_stability/nuget/check_api.py
+++ b/tests/api_stability/nuget/check_api.py
@@ -1,7 +1,62 @@
 #!/usr/bin/env python3
+"""Check NuGet package public API stability against a baseline snapshot.
+
+If no baseline exists, the test is skipped. If a baseline exists, the
+generated C# source files are scanned for ``public`` declarations and
+compared to the baseline.  Removed items cause a failure; new items
+are reported as non-breaking additions.
+"""
 from pathlib import Path
-baseline = Path(__file__).with_name('PublicAPI.Shipped.txt')
-if not baseline.exists():
-    print('NuGet API stability scaffold: no PublicAPI.Shipped.txt yet; skipping.')
-    raise SystemExit(0)
-print('NuGet API stability scaffold: compare current public API to PublicAPI.Shipped.txt here.')
+import re, sys
+
+ROOT = Path(__file__).resolve().parents[2]  # tests/
+GENERATED_DIR = ROOT / 'generated' / 'csharp'
+BASELINE = Path(__file__).with_name('PublicAPI.Shipped.txt')
+
+PUB_RE = re.compile(
+    r'public\s+(?:const|static|readonly|class|struct|enum|interface|delegate|void|int|uint|long|ulong|float|double|bool|string|byte|var)\s+(\w+)'
+)
+
+def collect_public_items() -> list[str]:
+    items = []
+    if not GENERATED_DIR.exists():
+        print(f'Generated directory not found: {GENERATED_DIR}', file=sys.stderr)
+        sys.exit(1)
+    for f in sorted(GENERATED_DIR.rglob('*.cs')):
+        rel = f.relative_to(GENERATED_DIR)
+        for line in f.read_text(errors='replace').splitlines():
+            m = PUB_RE.match(line.strip())
+            if m:
+                items.append(f'{rel}:{m.group(1)}')
+    return sorted(items)
+
+def main() -> int:
+    if not BASELINE.exists():
+        print('NuGet API stability: no PublicAPI.Shipped.txt yet; skipping.')
+        return 0
+
+    current = collect_public_items()
+    expected = [
+        l.strip() for l in BASELINE.read_text().splitlines()
+        if l.strip() and not l.startswith('#')
+    ]
+
+    removed = [e for e in expected if e not in current]
+    added = [c for c in current if c not in expected]
+
+    if removed:
+        print('NuGet API stability: BREAKING CHANGES detected:', file=sys.stderr)
+        for r in removed:
+            print(f'  REMOVED: {r}', file=sys.stderr)
+        return 1
+
+    if added:
+        print('NuGet API stability: new items added (non-breaking):')
+        for a in added:
+            print(f'  ADDED: {a}')
+
+    print(f'NuGet API stability: compatible ({len(current)} items checked).')
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/benchmarks/c/bench.c
+++ b/tests/benchmarks/c/bench.c
@@ -40,6 +40,19 @@ static void fletcher(const uint8_t* d, size_t n, uint8_t* o1, uint8_t* o2) {
   *o2 = (uint8_t)b;
 }
 
+static void verify_payload(const uint8_t* payload, size_t len) {
+  if (len == 0) return;
+  size_t checks[3] = {0, len / 2, len - 1};
+  for (size_t i = 0; i < 3; i++) {
+    size_t idx = checks[i];
+    uint8_t expected = (uint8_t)((idx * 31 + len) & 0xff);
+    if (payload[idx] != expected) {
+      fprintf(stderr, "bad payload\n");
+      exit(3);
+    }
+  }
+}
+
 static size_t encode(const char* profile, uint8_t type, size_t payload_len,
                      int network, uint8_t seq, uint8_t* out) {
   size_t b = 2;
@@ -92,6 +105,7 @@ static size_t decode(const uint8_t* f) {
     fprintf(stderr, "bad crc\n");
     exit(2);
   }
+  verify_payload(f + off, len);
   return len;
 }
 

--- a/tests/benchmarks/cpp/bench.cpp
+++ b/tests/benchmarks/cpp/bench.cpp
@@ -40,6 +40,19 @@ static void fletcher(const uint8_t* d, size_t n, uint8_t* o1, uint8_t* o2) {
   *o2 = (uint8_t)b;
 }
 
+static void verify_payload(const uint8_t* payload, size_t len) {
+  if (len == 0) return;
+  size_t checks[3] = {0, len / 2, len - 1};
+  for (size_t i = 0; i < 3; i++) {
+    size_t idx = checks[i];
+    uint8_t expected = (uint8_t)((idx * 31 + len) & 0xff);
+    if (payload[idx] != expected) {
+      fprintf(stderr, "bad payload\n");
+      exit(3);
+    }
+  }
+}
+
 static size_t encode(const char* profile, uint8_t type, size_t payload_len,
                      int network, uint8_t seq, uint8_t* out) {
   size_t b = 2;
@@ -92,6 +105,7 @@ static size_t decode(const uint8_t* f) {
     fprintf(stderr, "bad crc\n");
     exit(2);
   }
+  verify_payload(f + off, len);
   return len;
 }
 

--- a/tests/benchmarks/csharp/Program.cs
+++ b/tests/benchmarks/csharp/Program.cs
@@ -17,6 +17,19 @@ class P
         return ((byte)a, (byte)b);
     }
 
+    static void VerifyPayload(byte[] payload, int off, int len)
+    {
+        if (len == 0) return;
+        foreach (var idx in new[] { 0, len / 2, len - 1 })
+        {
+            byte expected = (byte)((idx * 31 + len) & 0xff);
+            if (payload[off + idx] != expected)
+            {
+                throw new Exception("bad payload");
+            }
+        }
+    }
+
     static byte[] Encode(Scenario s, byte seq)
     {
         var body = new List<byte>();
@@ -74,6 +87,7 @@ class P
         {
             throw new Exception("crc");
         }
+        VerifyPayload(f, off, len);
         return len;
     }
 

--- a/tests/benchmarks/python/bench.py
+++ b/tests/benchmarks/python/bench.py
@@ -15,6 +15,16 @@ def fletcher(data):
         a = (a + x) & 0xff; b = (b + a) & 0xff
     return a, b
 
+def verify_payload(payload):
+    payload_len = len(payload)
+    if payload_len == 0:
+        return
+    checks = {0, payload_len // 2, payload_len - 1}
+    for i in checks:
+        expected = (i * 31 + payload_len) & 0xff
+        if payload[i] != expected:
+            raise ValueError("bad payload")
+
 def encode(profile, type_byte, payload_len, network=False, seq=1):
     payload = bytes((i * 31 + payload_len) & 0xff for i in range(payload_len))
     body = bytearray()
@@ -42,7 +52,9 @@ def decode(frame):
     c1, c2 = fletcher(frame[2:end])
     if frame[end] != c1 or frame[end+1] != c2:
         raise ValueError("bad crc")
-    return frame[off:end]
+    payload = frame[off:end]
+    verify_payload(payload)
+    return payload
 
 def pct(values, q):
     values.sort(); return values[min(len(values)-1, int((len(values)-1) * q))]

--- a/tests/benchmarks/rust/src/main.rs
+++ b/tests/benchmarks/rust/src/main.rs
@@ -17,6 +17,17 @@ fn fletcher(data: &[u8]) -> (u8, u8) {
     (a as u8, b as u8)
 }
 
+fn verify_payload(payload: &[u8]) {
+    let payload_len = payload.len();
+    if payload_len == 0 {
+        return;
+    }
+    for idx in [0usize, payload_len / 2, payload_len - 1] {
+        let expected = ((idx * 31 + payload_len) & 0xff) as u8;
+        assert_eq!(payload[idx], expected, "bad payload");
+    }
+}
+
 fn encode(s: &Scenario, seq: u8) -> Vec<u8> {
     let mut body = Vec::new();
     if s.network {
@@ -53,6 +64,7 @@ fn decode(f: &[u8]) -> usize {
     }
     let (c1, c2) = fletcher(&f[2..off + len]);
     assert_eq!((f[off + len], f[off + len + 1]), (c1, c2));
+    verify_payload(&f[off..off + len]);
     len
 }
 

--- a/tests/benchmarks/ts/bench.ts
+++ b/tests/benchmarks/ts/bench.ts
@@ -20,6 +20,16 @@ function fletcher(buf: Buffer): [number, number] {
   return [a, b];
 }
 
+function verifyPayload(payload: Buffer): void {
+  const payloadLen = payload.length;
+  if (payloadLen === 0) return;
+  const checks = new Set([0, Math.floor(payloadLen / 2), payloadLen - 1]);
+  for (const i of checks) {
+    const expected = (i * 31 + payloadLen) & 0xff;
+    if (payload[i] !== expected) throw new Error('bad payload');
+  }
+}
+
 function encode(profile: string, typeByte: number, payloadLen: number, network = false, seq = 1): Buffer {
   const payload = Buffer.alloc(payloadLen);
   for (let i = 0; i < payloadLen; i++) {
@@ -57,7 +67,9 @@ function decode(frame: Buffer): Buffer {
   const end = off + len;
   const [c1, c2] = fletcher(frame.subarray(2, end));
   if (frame[end] !== c1 || frame[end + 1] !== c2) throw new Error('bad crc');
-  return frame.subarray(off, end);
+  const payload = frame.subarray(off, end);
+  verifyPayload(payload);
+  return payload;
 }
 
 function pct(v: number[], q: number): number {

--- a/tests/c/test_streaming.c
+++ b/tests/c/test_streaming.c
@@ -136,7 +136,11 @@ static bool test_streaming_sensor_positive(void) {
   if (!result.valid) return false;
   if (result.msg_id != SERIALIZATION_TEST_BASIC_TYPES_MESSAGE_MSG_ID) return false;
 
-  return true;
+  /* Deserialise and verify the payload field */
+  SerializationTestBasicTypesMessage decoded;
+  memset(&decoded, 0, sizeof(decoded));
+  SerializationTestBasicTypesMessage_deserialize(result.msg_data, result.msg_len, &decoded);
+  return decoded.small_int == 7;
 }
 
 /* ------------------------------------------------------------------

--- a/tests/cpp/test_sdk_subscribe.cpp
+++ b/tests/cpp/test_sdk_subscribe.cpp
@@ -25,6 +25,12 @@ using namespace structframe::serialization_test;
 using namespace structframe::sdk;
 
 // ============================================================================
+// SDK type alias for ProfileStandard + our get_message_info
+// ============================================================================
+
+using TestSdk = StructFrameSdkT<ProfileStandardConfig, decltype(&get_message_info)>;
+
+// ============================================================================
 // Mock transport
 // ============================================================================
 
@@ -46,33 +52,6 @@ class MockTransport : public BaseTransport {
   // Simulate incoming data from the peer
   void inject_data(const uint8_t* data, size_t length) {
     HandleData(data, length);
-  }
-};
-
-// ============================================================================
-// Mock frame_parser
-// ============================================================================
-
-/**
- * MockFrameParser - wraps AccumulatingReader<ProfileStandardConfig> so that
- * StructFrameSdk can parse real encoded frames in tests.
- */
-class MockFrameParser : public frame_parser {
- public:
-  int parse_calls = 0;
-
-  FrameMsgInfo parse(const uint8_t* data, size_t length) override {
-    parse_calls++;
-    return BufferParserWithCrc<ProfileStandardConfig>::parse(data, length,
-                                                             get_message_info);
-  }
-
-  size_t frame(uint8_t msgId, const uint8_t* data, size_t dataLen,
-               uint8_t* output, size_t outputMaxLen) override {
-    // frame() is only called by SendRaw(). SendRaw is not exercised by any
-    // test in this file, so this mock returns 0 (unsupported).
-    (void)msgId; (void)data; (void)dataLen; (void)output; (void)outputMaxLen;
-    return 0;
   }
 };
 
@@ -107,17 +86,11 @@ static bool inject_encoded_message(MockTransport& transport, const MessageT& msg
 // ============================================================================
 
 /**
- * Test: subscribe + NotifyObservers dispatches to a registered lambda callback
+ * Test: subscribe + incoming frame dispatches to a registered lambda callback
  */
 bool test_subscribe_dispatch_lambda() {
   MockTransport transport;
-  MockFrameParser parser;
-
-  StructFrameSdkConfig config;
-  config.transport = &transport;
-  config.parser = &parser;
-
-  StructFrameSdk sdk(config);
+  TestSdk sdk(&transport, &get_message_info);
 
   int call_count = 0;
   BasicTypesMessage received{};
@@ -139,7 +112,6 @@ bool test_subscribe_dispatch_lambda() {
   if (call_count != 1) return false;
   if (received.regular_int != 42) return false;
   if (!received.flag) return false;
-  if (parser.parse_calls == 0) return false;
 
   return true;
 }
@@ -149,13 +121,7 @@ bool test_subscribe_dispatch_lambda() {
  */
 bool test_subscribe_multiple_observers() {
   MockTransport transport;
-  MockFrameParser parser;
-
-  StructFrameSdkConfig config;
-  config.transport = &transport;
-  config.parser = &parser;
-
-  StructFrameSdk sdk(config);
+  TestSdk sdk(&transport, &get_message_info);
 
   int count_a = 0, count_b = 0;
 
@@ -171,7 +137,7 @@ bool test_subscribe_multiple_observers() {
   msg.regular_int = 99;
   if (!inject_encoded_message(transport, msg)) return false;
 
-  return count_a == 1 && count_b == 1 && parser.parse_calls > 0;
+  return count_a == 1 && count_b == 1;
 }
 
 /**
@@ -179,13 +145,7 @@ bool test_subscribe_multiple_observers() {
  */
 bool test_subscription_raii_unsubscribe() {
   MockTransport transport;
-  MockFrameParser parser;
-
-  StructFrameSdkConfig config;
-  config.transport = &transport;
-  config.parser = &parser;
-
-  StructFrameSdk sdk(config);
+  TestSdk sdk(&transport, &get_message_info);
 
   int count = 0;
 
@@ -206,7 +166,7 @@ bool test_subscription_raii_unsubscribe() {
   msg.regular_int = 456;
   if (!inject_encoded_message(transport, msg)) return false;
   // count should still be 1 (second notify has no subscriber)
-  return count == 1 && parser.parse_calls >= 2;
+  return count == 1;
 }
 
 /**
@@ -215,13 +175,7 @@ bool test_subscription_raii_unsubscribe() {
  */
 bool test_notify_unregistered_id_is_noop() {
   MockTransport transport;
-  MockFrameParser parser;
-
-  StructFrameSdkConfig config;
-  config.transport = &transport;
-  config.parser = &parser;
-
-  StructFrameSdk sdk(config);
+  TestSdk sdk(&transport, &get_message_info);
 
   // Register a handler for a known ID to verify it's NOT called for unregistered IDs
   int call_count = 0;
@@ -242,7 +196,7 @@ bool test_notify_unregistered_id_is_noop() {
   sdk.NotifyObservers<BasicTypesMessage>(BasicTypesMessage::MSG_ID, msg);
   if (call_count != 1) return false;  // handler must fire once for registered ID
 
-  return parser.parse_calls > 0;
+  return true;
 }
 
 /**
@@ -250,38 +204,26 @@ bool test_notify_unregistered_id_is_noop() {
  */
 bool test_sdk_connect_delegates_to_transport() {
   MockTransport transport;
-  MockFrameParser parser;
-
-  StructFrameSdkConfig config;
-  config.transport = &transport;
-  config.parser = &parser;
-
-  StructFrameSdk sdk(config);
+  TestSdk sdk(&transport, &get_message_info);
   sdk.Connect();
 
   return transport.connect_calls == 1 && sdk.IsConnected();
 }
 
 /**
- * Test: Incoming data from transport triggers frame_parser->parse() and
+ * Test: Incoming data from transport triggers parse and
  *       auto-dispatches to a registered subscriber.
  */
 bool test_incoming_data_triggers_parse() {
   MockTransport transport;
-  MockFrameParser parser;
-
-  StructFrameSdkConfig config;
-  config.transport = &transport;
-  config.parser = &parser;
-
-  StructFrameSdk sdk(config);
+  TestSdk sdk(&transport, &get_message_info);
 
   int dispatch_count = 0;
   auto sub = sdk.subscribe<BasicTypesMessage>(
       BasicTypesMessage::MSG_ID,
       [&](const BasicTypesMessage&, uint8_t) { dispatch_count++; });
 
-  // Encode a real frame and inject it so parse() is called
+  // Encode a real frame and inject it
   BasicTypesMessage msg{};
   msg.regular_int = 55;
   uint8_t encoded[512];
@@ -291,8 +233,8 @@ bool test_incoming_data_triggers_parse() {
 
   transport.inject_data(encoded, frame_len);
 
-  // parse() was called and auto-dispatch fired
-  return parser.parse_calls > 0 && dispatch_count == 1;
+  // auto-dispatch fired
+  return dispatch_count == 1;
 }
 
 /**
@@ -301,13 +243,7 @@ bool test_incoming_data_triggers_parse() {
  */
 bool test_end_to_end_parse_pipeline() {
   MockTransport transport;
-  MockFrameParser parser;
-
-  StructFrameSdkConfig config;
-  config.transport = &transport;
-  config.parser = &parser;
-
-  StructFrameSdk sdk(config);
+  TestSdk sdk(&transport, &get_message_info);
 
   int dispatch_count = 0;
   BasicTypesMessage dispatched{};
@@ -351,7 +287,7 @@ int main() {
   printf("%-65s %s\n",
     "=================================================================", "======");
 
-  run_test("subscribe + NotifyObservers dispatches to lambda",
+  run_test("subscribe + incoming frame dispatches to lambda",
            test_subscribe_dispatch_lambda);
   run_test("multiple observers all receive notification",
            test_subscribe_multiple_observers);
@@ -361,7 +297,7 @@ int main() {
            test_notify_unregistered_id_is_noop);
   run_test("Connect() delegates to transport",
            test_sdk_connect_delegates_to_transport);
-  run_test("Incoming transport data triggers parse() + dispatch",
+  run_test("Incoming transport data triggers parse + dispatch",
            test_incoming_data_triggers_parse);
   run_test("Full encode -> inject -> subscriber receives message",
            test_end_to_end_parse_pipeline);

--- a/tests/cpp/test_sdk_subscribe.cpp
+++ b/tests/cpp/test_sdk_subscribe.cpp
@@ -29,6 +29,29 @@ using namespace structframe::sdk;
 // ============================================================================
 
 using TestSdk = StructFrameSdkT<ProfileStandardConfig>;
+using TestBulkSdk = StructFrameSdkT<ProfileBulkConfig>;
+
+struct ExtendedDummyMessage {
+  static constexpr uint16_t MSG_ID = 300;
+  static constexpr size_t MAX_SIZE = 1;
+  static constexpr uint8_t MAGIC_1 = 0;
+  static constexpr uint8_t MAGIC_2 = 0;
+
+  uint8_t value = 0;
+
+  void deserialize(const uint8_t* data, size_t len) {
+    value = (data != nullptr && len > 0) ? data[0] : 0;
+  }
+};
+
+static MessageInfo get_extended_dummy_message_info(uint16_t msg_id) {
+  if (msg_id == ExtendedDummyMessage::MSG_ID) {
+    return MessageInfo(ExtendedDummyMessage::MAX_SIZE,
+                       ExtendedDummyMessage::MAGIC_1,
+                       ExtendedDummyMessage::MAGIC_2);
+  }
+  return MessageInfo();
+}
 
 // ============================================================================
 // Mock transport
@@ -359,6 +382,71 @@ bool test_forward_frame_info_between_two_sdks() {
   return true;
 }
 
+/**
+ * Test: extended message IDs (>255) are preserved through SendRaw + dispatch.
+ */
+bool test_extended_msg_id_sendraw_roundtrip() {
+  LoopbackTransport transport;
+  TestBulkSdk sdk(&transport, &get_extended_dummy_message_info);
+
+  int dispatch_count = 0;
+  uint16_t observed_msg_id = 0;
+  uint8_t observed_value = 0;
+
+  auto sub = sdk.subscribe<ExtendedDummyMessage>(
+      ExtendedDummyMessage::MSG_ID,
+      [&](const ExtendedDummyMessage& msg, uint16_t msg_id) {
+        dispatch_count++;
+        observed_msg_id = msg_id;
+        observed_value = msg.value;
+      });
+
+  uint8_t payload[ExtendedDummyMessage::MAX_SIZE] = {0xAB};
+  if (!sdk.SendRaw(ExtendedDummyMessage::MSG_ID, payload, sizeof(payload))) return false;
+
+  return dispatch_count == 1 &&
+         observed_msg_id == ExtendedDummyMessage::MSG_ID &&
+         observed_value == payload[0];
+}
+
+/**
+ * Test: forwarding FrameMsgInfo preserves extended message IDs (>255).
+ */
+bool test_forward_extended_msg_id_between_two_sdks() {
+  LoopbackTransport source_transport;
+  LoopbackTransport target_transport;
+  TestBulkSdk source_sdk(&source_transport, &get_extended_dummy_message_info);
+  TestBulkSdk target_sdk(&target_transport, &get_extended_dummy_message_info);
+
+  int target_dispatch_count = 0;
+  int forwarded_from_source = 0;
+  uint16_t observed_msg_id = 0;
+  uint8_t observed_value = 0;
+
+  auto target_sub = target_sdk.subscribe<ExtendedDummyMessage>(
+      ExtendedDummyMessage::MSG_ID,
+      [&](const ExtendedDummyMessage& msg, uint16_t msg_id) {
+        target_dispatch_count++;
+        observed_msg_id = msg_id;
+        observed_value = msg.value;
+      });
+
+  auto forward_sub = source_sdk.subscribeFrameInfo(
+      [&](const FrameMsgInfo& frame) {
+        if (target_sdk.Send(frame)) {
+          forwarded_from_source++;
+        }
+      });
+
+  uint8_t payload[ExtendedDummyMessage::MAX_SIZE] = {0x6C};
+  if (!source_sdk.SendRaw(ExtendedDummyMessage::MSG_ID, payload, sizeof(payload))) return false;
+
+  return forwarded_from_source == 1 &&
+         target_dispatch_count == 1 &&
+         observed_msg_id == ExtendedDummyMessage::MSG_ID &&
+         observed_value == payload[0];
+}
+
 // ============================================================================
 // Main
 // ============================================================================
@@ -389,6 +477,10 @@ int main() {
            test_subscribe_frame_info_receives_valid_frames);
   run_test("FrameMsgInfo forwarding works across two SDK instances",
            test_forward_frame_info_between_two_sdks);
+  run_test("SendRaw preserves extended msg_id (>255) during dispatch",
+           test_extended_msg_id_sendraw_roundtrip);
+  run_test("FrameMsgInfo forwarding preserves extended msg_id (>255)",
+           test_forward_extended_msg_id_between_two_sdks);
 
   printf("\n========================================\n");
   printf("Summary: %d/%d tests passed\n", tests_passed, tests_run);

--- a/tests/cpp/test_sdk_subscribe.cpp
+++ b/tests/cpp/test_sdk_subscribe.cpp
@@ -25,10 +25,10 @@ using namespace structframe::serialization_test;
 using namespace structframe::sdk;
 
 // ============================================================================
-// SDK type alias for ProfileStandard + our get_message_info
+// SDK type alias for ProfileStandard
 // ============================================================================
 
-using TestSdk = StructFrameSdkT<ProfileStandardConfig, decltype(&get_message_info)>;
+using TestSdk = StructFrameSdkT<ProfileStandardConfig>;
 
 // ============================================================================
 // Mock transport
@@ -51,6 +51,22 @@ class MockTransport : public BaseTransport {
 
   // Simulate incoming data from the peer
   void inject_data(const uint8_t* data, size_t length) {
+    HandleData(data, length);
+  }
+};
+
+/**
+ * LoopbackTransport - anything sent is immediately fed back as incoming data.
+ * Useful for verifying end-to-end forwarding into another SDK instance.
+ */
+class LoopbackTransport : public BaseTransport {
+ public:
+  std::vector<std::vector<uint8_t>> sent_data;
+
+  void Connect() override { connected_ = true; }
+  void Disconnect() override { connected_ = false; }
+  void Send(const uint8_t* data, size_t length) override {
+    sent_data.push_back(std::vector<uint8_t>(data, data + length));
     HandleData(data, length);
   }
 };
@@ -275,6 +291,74 @@ bool test_end_to_end_parse_pipeline() {
   return true;
 }
 
+/**
+ * Test: subscribeFrameInfo receives each valid parsed frame.
+ */
+bool test_subscribe_frame_info_receives_valid_frames() {
+  MockTransport transport;
+  TestSdk sdk(&transport, &get_message_info);
+
+  int frame_count = 0;
+  uint16_t last_msg_id = 0;
+  size_t last_msg_len = 0;
+
+  auto sub = sdk.subscribeFrameInfo(
+      [&](const FrameMsgInfo& frame) {
+        frame_count++;
+        last_msg_id = frame.msg_id;
+        last_msg_len = frame.msg_len;
+      });
+
+  BasicTypesMessage msg{};
+  msg.regular_int = 314;
+  if (!inject_encoded_message(transport, msg)) return false;
+
+  return frame_count == 1 &&
+         last_msg_id == BasicTypesMessage::MSG_ID &&
+         last_msg_len == BasicTypesMessage::MAX_SIZE;
+}
+
+/**
+ * Test: forwarding FrameMsgInfo between two SDK instances via Send(frame_info).
+ */
+bool test_forward_frame_info_between_two_sdks() {
+  MockTransport source_transport;
+  LoopbackTransport target_transport;
+
+  TestSdk source_sdk(&source_transport, &get_message_info);
+  TestSdk target_sdk(&target_transport, &get_message_info);
+
+  int target_dispatch_count = 0;
+  int forwarded_from_source = 0;
+  BasicTypesMessage target_received{};
+
+  auto target_sub = target_sdk.subscribe<BasicTypesMessage>(
+      BasicTypesMessage::MSG_ID,
+      [&](const BasicTypesMessage& msg, uint8_t) {
+        target_dispatch_count++;
+        target_received = msg;
+      });
+
+  auto forward_sub = source_sdk.subscribeFrameInfo(
+      [&](const FrameMsgInfo& frame) {
+        if (target_sdk.Send(frame)) {
+          forwarded_from_source++;
+        }
+      });
+
+  BasicTypesMessage msg{};
+  msg.regular_int = 909;
+  msg.flag = true;
+  if (!inject_encoded_message(source_transport, msg)) return false;
+
+  if (forwarded_from_source != 1) return false;
+  if (target_dispatch_count != 1) return false;
+  if (target_received.regular_int != 909) return false;
+  if (!target_received.flag) return false;
+
+  return true;
+}
+
 // ============================================================================
 // Main
 // ============================================================================
@@ -301,6 +385,10 @@ int main() {
            test_incoming_data_triggers_parse);
   run_test("Full encode -> inject -> subscriber receives message",
            test_end_to_end_parse_pipeline);
+  run_test("subscribeFrameInfo receives valid parsed frames",
+           test_subscribe_frame_info_receives_valid_frames);
+  run_test("FrameMsgInfo forwarding works across two SDK instances",
+           test_forward_frame_info_between_two_sdks);
 
   printf("\n========================================\n");
   printf("Summary: %d/%d tests passed\n", tests_passed, tests_run);

--- a/tests/cpp/test_sdk_subscribe.cpp
+++ b/tests/cpp/test_sdk_subscribe.cpp
@@ -69,24 +69,10 @@ class MockFrameParser : public frame_parser {
 
   size_t frame(uint8_t msgId, const uint8_t* data, size_t dataLen,
                uint8_t* output, size_t outputMaxLen) override {
-    // Minimal passthrough: copy payload with a trivial header for test purposes.
-    // Full framing is not needed for send tests in this file.
-    if (outputMaxLen < dataLen + 6) return 0;
-    // Build a standard frame manually using BufferWriter
-    std::vector<uint8_t> tmp(512);
-    BufferWriter<ProfileStandardConfig> writer(tmp.data(), tmp.size());
-    // We don't have a typed message here — copy raw via encode_with_crc
-    // For send tests, just mirror the raw bytes into output.
-    if (dataLen + 6 > outputMaxLen) return 0;
-    output[0] = ProfileStandardConfig::computed_start_byte1();
-    output[1] = ProfileStandardConfig::computed_start_byte2();
-    output[2] = static_cast<uint8_t>(dataLen);
-    output[3] = msgId;
-    memcpy(output + 4, data, dataLen);
-    // CRC omitted for this mock framer – sufficient for dispatch tests
-    output[4 + dataLen] = 0x00;
-    output[5 + dataLen] = 0x00;
-    return dataLen + 6;
+    // frame() is only called by SendRaw(). SendRaw is not exercised by any
+    // test in this file, so this mock returns 0 (unsupported).
+    (void)msgId; (void)data; (void)dataLen; (void)output; (void)outputMaxLen;
+    return 0;
   }
 };
 
@@ -104,6 +90,16 @@ static void run_test(const char* name, bool (*func)()) {
   printf("%-65s %s\n", name, passed ? "PASS" : "FAIL");
   if (passed) tests_passed++;
   else tests_failed++;
+}
+
+template <typename MessageT>
+static bool inject_encoded_message(MockTransport& transport, const MessageT& msg) {
+  uint8_t encoded[512];
+  size_t frame_len =
+      FrameEncoderWithCrc<ProfileStandardConfig>::encode(encoded, sizeof(encoded), msg);
+  if (frame_len == 0) return false;
+  transport.inject_data(encoded, frame_len);
+  return true;
 }
 
 // ============================================================================
@@ -133,16 +129,17 @@ bool test_subscribe_dispatch_lambda() {
         received = msg;
       });
 
-  // Build a test message and dispatch manually
+  // Build a test message and inject a real frame through the transport.
   BasicTypesMessage sent{};
   sent.regular_int = 42;
   sent.flag = true;
 
-  sdk.NotifyObservers<BasicTypesMessage>(BasicTypesMessage::MSG_ID, sent);
+  if (!inject_encoded_message(transport, sent)) return false;
 
   if (call_count != 1) return false;
   if (received.regular_int != 42) return false;
   if (!received.flag) return false;
+  if (parser.parse_calls == 0) return false;
 
   return true;
 }
@@ -171,9 +168,10 @@ bool test_subscribe_multiple_observers() {
       [&](const BasicTypesMessage&, uint8_t) { count_b++; });
 
   BasicTypesMessage msg{};
-  sdk.NotifyObservers<BasicTypesMessage>(BasicTypesMessage::MSG_ID, msg);
+  msg.regular_int = 99;
+  if (!inject_encoded_message(transport, msg)) return false;
 
-  return count_a == 1 && count_b == 1;
+  return count_a == 1 && count_b == 1 && parser.parse_calls > 0;
 }
 
 /**
@@ -198,19 +196,22 @@ bool test_subscription_raii_unsubscribe() {
         [&](const BasicTypesMessage&, uint8_t) { count++; });
 
     BasicTypesMessage msg{};
-    sdk.NotifyObservers<BasicTypesMessage>(BasicTypesMessage::MSG_ID, msg);
+    msg.regular_int = 123;
+    if (!inject_encoded_message(transport, msg)) return false;
     if (count != 1) return false;  // handler should fire once while active
   }
   // sub destroyed → auto-unsubscribed
 
   BasicTypesMessage msg{};
-  sdk.NotifyObservers<BasicTypesMessage>(BasicTypesMessage::MSG_ID, msg);
+  msg.regular_int = 456;
+  if (!inject_encoded_message(transport, msg)) return false;
   // count should still be 1 (second notify has no subscriber)
-  return count == 1;
+  return count == 1 && parser.parse_calls >= 2;
 }
 
 /**
  * Test: NotifyObservers for an unregistered message ID is a no-op (no crash)
+ *       and does not invoke any registered handlers.
  */
 bool test_notify_unregistered_id_is_noop() {
   MockTransport transport;
@@ -222,10 +223,26 @@ bool test_notify_unregistered_id_is_noop() {
 
   StructFrameSdk sdk(config);
 
+  // Register a handler for a known ID to verify it's NOT called for unregistered IDs
+  int call_count = 0;
+  auto sub = sdk.subscribe<BasicTypesMessage>(
+      BasicTypesMessage::MSG_ID,
+      [&](const BasicTypesMessage&, uint8_t) { call_count++; });
+
+  // Inject a valid frame for a different message type that has no subscriber.
+  SerializationTestMessage other_msg{};
+  other_msg.magic_number = 0x12345678;
+  other_msg.test_float = 1.5f;
+  other_msg.test_bool = true;
+  if (!inject_encoded_message(transport, other_msg)) return false;
+  if (call_count != 0) return false;  // handler must not fire for unregistered ID
+
+  // Verify the handler DOES fire for the registered ID
   BasicTypesMessage msg{};
-  // MSG_ID 0xFF is not subscribed — should not crash
-  sdk.NotifyObservers<BasicTypesMessage>(0xFF, msg);
-  return true;
+  sdk.NotifyObservers<BasicTypesMessage>(BasicTypesMessage::MSG_ID, msg);
+  if (call_count != 1) return false;  // handler must fire once for registered ID
+
+  return parser.parse_calls > 0;
 }
 
 /**
@@ -246,7 +263,8 @@ bool test_sdk_connect_delegates_to_transport() {
 }
 
 /**
- * Test: Incoming data from transport triggers frame_parser->parse()
+ * Test: Incoming data from transport triggers frame_parser->parse() and
+ *       auto-dispatches to a registered subscriber.
  */
 bool test_incoming_data_triggers_parse() {
   MockTransport transport;
@@ -258,21 +276,28 @@ bool test_incoming_data_triggers_parse() {
 
   StructFrameSdk sdk(config);
 
-  // Inject some bytes (even if not a valid frame)
-  uint8_t dummy[8] = {0x90, 0x71, 0x02, 0x01, 0xAA, 0xBB, 0x00, 0x00};
-  transport.inject_data(dummy, sizeof(dummy));
+  int dispatch_count = 0;
+  auto sub = sdk.subscribe<BasicTypesMessage>(
+      BasicTypesMessage::MSG_ID,
+      [&](const BasicTypesMessage&, uint8_t) { dispatch_count++; });
 
-  // The parser's parse() should have been called at least once
-  return parser.parse_calls > 0;
+  // Encode a real frame and inject it so parse() is called
+  BasicTypesMessage msg{};
+  msg.regular_int = 55;
+  uint8_t encoded[512];
+  size_t frame_len =
+      FrameEncoderWithCrc<ProfileStandardConfig>::encode(encoded, sizeof(encoded), msg);
+  if (frame_len == 0) return false;
+
+  transport.inject_data(encoded, frame_len);
+
+  // parse() was called and auto-dispatch fired
+  return parser.parse_calls > 0 && dispatch_count == 1;
 }
 
 /**
- * Test: Full end-to-end — encode a frame, inject via transport, ParseBuffer
- *       calls parse(), and the parsed result is available for NotifyObservers.
- *
- * Since StructFrameSdk::ParseBuffer() does not auto-dispatch (by design —
- * typed dispatch requires explicit NotifyObservers), this test verifies that
- * the pipeline up to ParseBuffer works correctly.
+ * Test: Full end-to-end — encode a frame, inject via transport, SDK
+ *       auto-dispatches to the registered subscriber with the correct data.
  */
 bool test_end_to_end_parse_pipeline() {
   MockTransport transport;
@@ -284,6 +309,15 @@ bool test_end_to_end_parse_pipeline() {
 
   StructFrameSdk sdk(config);
 
+  int dispatch_count = 0;
+  BasicTypesMessage dispatched{};
+  auto sub = sdk.subscribe<BasicTypesMessage>(
+      BasicTypesMessage::MSG_ID,
+      [&](const BasicTypesMessage& m, uint8_t) {
+          dispatch_count++;
+          dispatched = m;
+      });
+
   // Encode a real frame
   BasicTypesMessage msg{};
   msg.regular_int = 777;
@@ -292,16 +326,17 @@ bool test_end_to_end_parse_pipeline() {
   uint8_t encoded[512];
   size_t frame_len =
       FrameEncoderWithCrc<ProfileStandardConfig>::encode(encoded, sizeof(encoded), msg);
-
   if (frame_len == 0) return false;
 
-  int parse_calls_before = parser.parse_calls;
-
-  // Inject the complete frame
+  // Inject the complete frame via the transport
   transport.inject_data(encoded, frame_len);
 
-  // parse() must have been invoked at least once
-  return parser.parse_calls > parse_calls_before;
+  // Subscriber must have been called with the correct decoded values
+  if (dispatch_count != 1) return false;
+  if (dispatched.regular_int != 777) return false;
+  if (dispatched.flag != false) return false;
+
+  return true;
 }
 
 // ============================================================================
@@ -326,9 +361,9 @@ int main() {
            test_notify_unregistered_id_is_noop);
   run_test("Connect() delegates to transport",
            test_sdk_connect_delegates_to_transport);
-  run_test("Incoming transport data triggers parse()",
+  run_test("Incoming transport data triggers parse() + dispatch",
            test_incoming_data_triggers_parse);
-  run_test("Full encode -> inject -> ParseBuffer pipeline",
+  run_test("Full encode -> inject -> subscriber receives message",
            test_end_to_end_parse_pipeline);
 
   printf("\n========================================\n");

--- a/tests/cpp/test_sdk_units.cpp
+++ b/tests/cpp/test_sdk_units.cpp
@@ -110,7 +110,7 @@ bool test_encoder_with_crc_bulk_profile() {
       buffer, encoded, get_message_info);
 
   if (!result.valid) return false;
-  if ((result.msg_id & 0xFF) != (BasicTypesMessage::MSG_ID & 0xFF)) return false;
+  if (result.msg_id != BasicTypesMessage::MSG_ID) return false;
 
   return true;
 }
@@ -151,6 +151,12 @@ bool test_encoder_minimal_roundtrip() {
   // Sensor profile overhead: 1 start byte + 1 msg_id = 2 bytes header, 0 footer
   size_t expected_size = ProfileSensorConfig::overhead + BasicTypesMessage::MAX_SIZE;
   if (encoded != expected_size) return false;
+
+  // Parse it back to verify round-trip
+  auto result = BufferParserMinimal<ProfileSensorConfig>::parse(
+      buffer, encoded, get_message_info);
+  if (!result.valid) return false;
+  if (result.msg_id != BasicTypesMessage::MSG_ID) return false;
 
   return true;
 }
@@ -202,6 +208,12 @@ bool test_encoder_minimal_ipc_profile() {
   // IPC profile: no start bytes, just msg_id + payload
   size_t expected_size = ProfileIPCConfig::overhead + BasicTypesMessage::MAX_SIZE;
   if (encoded != expected_size) return false;
+
+  // Parse it back to verify round-trip
+  auto result = BufferParserMinimal<ProfileIPCConfig>::parse(
+      buffer, encoded, get_message_info);
+  if (!result.valid) return false;
+  if (result.msg_id != BasicTypesMessage::MSG_ID) return false;
 
   return true;
 }

--- a/tests/csharp/StructFrameTests.csproj
+++ b/tests/csharp/StructFrameTests.csproj
@@ -7,4 +7,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StartupObject>TestRunner</StartupObject>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\generated\csharp\StructFrame.csproj" />
+  </ItemGroup>
 </Project>

--- a/tests/csharp/StructFrameTests.csproj
+++ b/tests/csharp/StructFrameTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>disable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/tests/csharp/StructFrameTests.csproj
+++ b/tests/csharp/StructFrameTests.csproj
@@ -7,8 +7,4 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StartupObject>TestRunner</StartupObject>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\generated\csharp\StructFrame.csproj" />
-  </ItemGroup>
 </Project>

--- a/tests/py/test_sdk.py
+++ b/tests/py/test_sdk.py
@@ -218,10 +218,19 @@ def test_no_handler_for_unknown_id():
     fired = [False]
     sdk.subscribe(BasicTypesMessage.MSG_ID, lambda *_: fired.__setitem__(0, True))
 
+    # Test 1: known ID fires the handler
     msg = BasicTypesMessage()
     transport.inject_data(encode_basic_types(msg))
-
     run_test("known id: handler fires", fired[0] is True)
+
+    # Test 2: unknown ID does not fire the handler
+    fired[0] = False
+    # Encode a frame with a message ID that has no subscriber
+    UNKNOWN_MSG_ID = 0xFFFE
+    parser = StandardFrameParser()
+    unknown_frame = parser.frame(UNKNOWN_MSG_ID, b'\x00' * 4)
+    transport.inject_data(unknown_frame)
+    run_test("unknown id: handler does not fire", fired[0] is False)
 
 
 def test_send_raw_frames_through_transport():

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -260,11 +260,13 @@ class TimedPhase:
 class TestRunner:
     """Main test runner class."""
     
-    def __init__(self, verbose: bool = False, quiet: bool = False):
+    def __init__(self, verbose: bool = False, quiet: bool = False,
+                 dotnet_framework: Optional[str] = None):
         self.verbose = verbose
         self.quiet = quiet
         self.project_root = Path(__file__).parent.parent
         self.tests_dir = self.project_root / "tests"
+        self.dotnet_framework = self._resolve_dotnet_framework(dotnet_framework)
         
         self.languages = self._init_languages()
         self.skipped_languages: List[str] = []
@@ -293,6 +295,18 @@ class TestRunner:
             "variable_decode": {},
             "negative": {},
         }
+
+    def _resolve_dotnet_framework(self, explicit_framework: Optional[str]) -> str:
+        """Resolve the C# framework used by the test runner."""
+        tfm = (explicit_framework or os.environ.get("SF_DOTNET_TFM", "")).strip().lower()
+        if tfm:
+            return tfm
+        ok, stdout, _ = self.run_cmd("dotnet --version", timeout=10)
+        if ok and stdout:
+            major = stdout.strip().split(".")[0]
+            if major.isdigit():
+                return f"net{major}.0"
+        return "net8.0"
     
     def _init_languages(self) -> Dict[str, Language]:
         """Initialize language configurations."""
@@ -364,7 +378,7 @@ class TestRunner:
                 compiler_check="dotnet --version",
                 interpreter="dotnet",
                 test_dir="tests/csharp",
-                build_dir="tests/csharp/bin/Release/net10.0",
+                build_dir=f"tests/csharp/bin/Release/{self.dotnet_framework}",
                 source_ext=".cs",
             ),
             "rust": Language(
@@ -740,7 +754,10 @@ class TestRunner:
         if lang.id == "csharp":
             csproj = test_dir / "StructFrameTests.csproj"
             if csproj.exists():
-                cmd = f'dotnet build "{csproj}" -c Release -o "{build_dir}" --verbosity quiet'
+                cmd = (
+                    f'dotnet build "{csproj}" -c Release --framework {self.dotnet_framework} '
+                    f'-o "{build_dir}" --verbosity quiet'
+                )
                 success, _, _ = self.run_cmd(cmd)
                 
                 # Also verify transport implementations compile
@@ -748,7 +765,10 @@ class TestRunner:
                 if gen_csproj.exists():
                     transport_build_dir = build_dir / "transport_verify"
                     transport_build_dir.mkdir(parents=True, exist_ok=True)
-                    transport_cmd = f'dotnet build "{gen_csproj}" -c Release -o "{transport_build_dir}" -p:IncludeTransports=true --verbosity quiet'
+                    transport_cmd = (
+                        f'dotnet build "{gen_csproj}" -c Release --framework {self.dotnet_framework} '
+                        f'-o "{transport_build_dir}" -p:IncludeTransports=true --verbosity quiet'
+                    )
                     transport_ok, _, _ = self.run_cmd(transport_cmd)
                     if not transport_ok:
                         print(f"  WARNING: Transport compilation verification failed (transport files may have errors)")
@@ -2166,7 +2186,7 @@ class TestRunner:
                     # with shared OutputPath; mirrors the convention used for
                     # the C# test runner above).
                     build_cmd = (
-                        f'dotnet build "{csproj}" -c Release --framework net8.0 '
+                        f'dotnet build "{csproj}" -c Release --framework {self.dotnet_framework} '
                         f'-p:OutputType=Exe -p:StartupObject={startup} '
                         f'-p:GenerateDocumentationFile=false '
                         f'-p:BaseIntermediateOutputPath="{out_dir}/obj/" '
@@ -2465,6 +2485,7 @@ class TestRunner:
         """
         print(Colors.bold("Starting struct-frame Test Suite"))
         print(f"Project root: {self.project_root}")
+        print(f"C# target framework: {self.dotnet_framework}")
         
         start_time = time.time()
         
@@ -2654,6 +2675,8 @@ Examples:
                         help="Disable colored output")
     parser.add_argument("--profiling", action="store_true", 
                         help="Run only time profiling tests (skips standard/extended/variable tests)")
+    parser.add_argument("--dotnet-framework", default=None,
+                        help="C# target framework moniker (e.g., net8.0, net10.0). Overrides SF_DOTNET_TFM.")
     
     args = parser.parse_args()
     
@@ -2667,7 +2690,11 @@ Examples:
         print(f"{Colors.warn_tag()} Cannot skip 'cpp' - it is required as the base encoder for decode tests")
         skip_languages = [lang for lang in skip_languages if lang != "cpp"]
     
-    runner = TestRunner(verbose=args.verbose, quiet=args.quiet)
+    runner = TestRunner(
+        verbose=args.verbose,
+        quiet=args.quiet,
+        dotnet_framework=args.dotnet_framework,
+    )
     if skip_languages:
         runner.skipped_languages = skip_languages
     

--- a/tests/test_equality.py
+++ b/tests/test_equality.py
@@ -76,7 +76,7 @@ def test_python_equality(gen_dir: Path) -> None:
     try:
         from struct_frame.generated.serialization_test import BasicTypesMessage  # type: ignore
     except ImportError as exc:
-        print(f"SKIP: cannot import generated Python module: {exc}")
+        _check(False, f"failed to import generated Python module: {exc}")
         return
     finally:
         sys.path.pop(0)
@@ -84,14 +84,41 @@ def test_python_equality(gen_dir: Path) -> None:
     a = BasicTypesMessage()
     a.small_int = 42
     a.medium_int = 1000
+    a.regular_int = 9876
+    a.large_int = -123456789
+    a.small_uint = 200
+    a.medium_uint = 50000
+    a.regular_uint = 300000
+    a.large_uint = 999999999
+    a.single_precision = 3.14
+    a.double_precision = 2.71828
+    a.flag = True
 
     b = BasicTypesMessage()
     b.small_int = 42
     b.medium_int = 1000
+    b.regular_int = 9876
+    b.large_int = -123456789
+    b.small_uint = 200
+    b.medium_uint = 50000
+    b.regular_uint = 300000
+    b.large_uint = 999999999
+    b.single_precision = 3.14
+    b.double_precision = 2.71828
+    b.flag = True
 
     c = BasicTypesMessage()
-    c.small_int = 99
+    c.small_int = 99  # differs from a
     c.medium_int = 1000
+    c.regular_int = 9876
+    c.large_int = -123456789
+    c.small_uint = 200
+    c.medium_uint = 50000
+    c.regular_uint = 300000
+    c.large_uint = 999999999
+    c.single_precision = 3.14
+    c.double_precision = 2.71828
+    c.flag = True
 
     _check(a == b, "equal messages should compare as equal")
     _check(not (a == c), "messages with differing fields should not be equal")
@@ -190,12 +217,13 @@ def test_ts_equality(gen_dir: Path) -> None:
     node_modules = repo_ts_dir / "node_modules"
     # Write a minimal tsconfig so tsc can compile standalone
     tsconfig = ts_dir / "tsconfig.json"
+    type_roots = f'"typeRoots":["{(node_modules / "@types").as_posix()}"],' if node_modules.exists() else ''
+    types = '"types":["node"],' if node_modules.exists() else ''
     tsconfig.write_text(
         '{"compilerOptions":{"target":"ES2020","module":"commonjs",'
         '"outDir":"./build","strict":false,"skipLibCheck":true,'
-        f'"typeRoots":["{node_modules / "@types"}"],"types":["node"],'
-        '"lib":["ES2020"],'
-        '"ignoreDeprecations":"6.0"},"include":["*.ts"]}',
+        f'{type_roots}{types}'
+        '"lib":["ES2020"]},"include":["*.ts"]}',
         encoding="utf-8",
     )
     # Determine field names: TS generator uses camelCase
@@ -347,7 +375,7 @@ def test_rust_equality(gen_dir: Path) -> None:
         'version = "0.1.0"\n'
         'edition = "2021"\n'
         "\n[dependencies]\n"
-        f'struct_frame_sdk = {{ path = "{rust_lib_dir}" }}\n',
+        f'struct_frame_sdk = {{ path = "{rust_lib_dir.as_posix()}" }}\n',
         encoding="utf-8",
     )
     src_dir = test_proj / "src"
@@ -380,31 +408,31 @@ def test_equality_flag():
         _run_generator(gen_dir)
 
         # 1. Verify equality functions / operators are present in generated code
-        c_header = (gen_dir / "c" / "serialization_test.structframe.h").read_text()
+        c_header = (gen_dir / "c" / "serialization_test.structframe.h").read_text(encoding="utf-8")
         _check("_equals(" in c_header,
                "C header should contain *_equals() functions")
 
-        cpp_header = (gen_dir / "cpp" / "serialization_test.structframe.hpp").read_text()
+        cpp_header = (gen_dir / "cpp" / "serialization_test.structframe.hpp").read_text(encoding="utf-8")
         _check("operator==" in cpp_header,
                "C++ header should contain operator== methods")
 
         py_files = list((gen_dir / "py").rglob("*.py"))
-        _check(any("def __eq__" in f.read_text() for f in py_files),
+        _check(any("def __eq__" in f.read_text(encoding="utf-8") for f in py_files),
                "Generated Python files should contain __eq__ methods")
 
-        ts_src = (gen_dir / "ts" / "serialization-test.structframe.ts").read_text()
+        ts_src = (gen_dir / "ts" / "serialization-test.structframe.ts").read_text(encoding="utf-8")
         _check("equals(" in ts_src,
                "Generated TypeScript file should contain equals() method")
 
-        js_src = (gen_dir / "js" / "serialization-test.structframe.js").read_text()
+        js_src = (gen_dir / "js" / "serialization-test.structframe.js").read_text(encoding="utf-8")
         _check("equals(" in js_src,
                "Generated JavaScript file should contain equals() method")
 
         cs_files = list((gen_dir / "csharp").rglob("*.cs"))
-        _check(any("Equals(" in f.read_text() for f in cs_files),
+        _check(any("Equals(" in f.read_text(encoding="utf-8", errors="replace") for f in cs_files),
                "Generated C# files should contain Equals() method")
 
-        rust_src = (gen_dir / "rust" / "serialization_test.structframe.rs").read_text()
+        rust_src = (gen_dir / "rust" / "serialization_test.structframe.rs").read_text(encoding="utf-8")
         _check("PartialEq" in rust_src,
                "Generated Rust file should derive PartialEq")
 

--- a/tests/test_generator_validation.py
+++ b/tests/test_generator_validation.py
@@ -396,27 +396,31 @@ message Foo {
 
 if __name__ == "__main__":
     print("Running generator validation tests...\n")
-    results = [
+    test_fns = [
         # Original three TODO cases + the working multi-package check
-        test_duplicate_msgid(),
-        test_duplicate_pkgid(),
-        test_circular_import(),
-        test_multi_package_missing_pkgid(),
+        test_duplicate_msgid,
+        test_duplicate_pkgid,
+        test_circular_import,
+        test_multi_package_missing_pkgid,
         # Tier B §3 additions (10 new TODO cases from test-coverage.md §8)
-        test_duplicate_field_numbers(),
-        test_array_missing_size(),
-        test_string_missing_size(),
-        test_string_array_missing_element_size(),
-        test_array_max_size_overflow(),
-        test_envelope_zero_oneofs(),
-        test_envelope_non_message_oneof_fields(),
-        test_envelope_msgid_discriminator_without_msgid(),
-        test_invalid_discriminator_value(),
-        test_field_number_zero(),
+        test_duplicate_field_numbers,
+        test_array_missing_size,
+        test_string_missing_size,
+        test_string_array_missing_element_size,
+        test_array_max_size_overflow,
+        test_envelope_zero_oneofs,
+        test_envelope_non_message_oneof_fields,
+        test_envelope_msgid_discriminator_without_msgid,
+        test_invalid_discriminator_value,
+        test_field_number_zero,
     ]
+    results = [fn() for fn in test_fns]
     passed = sum(results)
     total = len(results)
+    todo_count = total - passed
     print(f"\n{passed}/{total} tests passed.")
-    print("(Tests marked TODO document desired behaviour not yet implemented in the generator.)")
-    # Exit 0 even when TODO tests fail — they are known pending items, not regressions.
-    sys.exit(0)
+    if todo_count > 0:
+        print(f"{todo_count} test(s) marked TODO — generator does not yet reject these inputs.")
+        print("These are known pending items, not regressions, but are tracked as failures.")
+        print("Implement the corresponding generator checks to make them pass.")
+    sys.exit(0 if todo_count == 0 else 1)

--- a/tests/test_generator_validation.py
+++ b/tests/test_generator_validation.py
@@ -271,10 +271,10 @@ message Foo {
     return _report("string_array_missing_element_size", _rejected(result), expected_reject=True)
 
 
-def test_array_max_size_overflow() -> bool:
-    """An array with `max_size > 255` must be rejected (single-byte count)."""
+def test_array_max_size_over_255_allowed() -> bool:
+    """An array with `max_size > 255` must be accepted (two-byte count)."""
     proto = """\
-package max_size_overflow_test;
+package max_size_over_255_allowed_test;
 
 message Foo {
   option msgid = 1;
@@ -282,10 +282,27 @@ message Foo {
 }
 """
     with tempfile.TemporaryDirectory() as tmp:
-        sf = Path(tmp) / "max_size_overflow.sf"
+        sf = Path(tmp) / "max_size_over_255_allowed.sf"
         sf.write_text(proto)
         result = _run(str(sf))
-    return _report("array_max_size_greater_than_255", _rejected(result), expected_reject=True)
+    return _report("array_max_size_greater_than_255_allowed", _rejected(result), expected_reject=False)
+
+
+def test_string_max_size_over_255_allowed() -> bool:
+    """A string with `max_size > 255` must be accepted (two-byte length)."""
+    proto = """\
+package string_max_size_over_255_allowed_test;
+
+message Foo {
+  option msgid = 1;
+  string name = 1 [max_size = 300];
+}
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        sf = Path(tmp) / "string_max_size_over_255_allowed.sf"
+        sf.write_text(proto)
+        result = _run(str(sf))
+    return _report("string_max_size_greater_than_255_allowed", _rejected(result), expected_reject=False)
 
 
 def test_envelope_zero_oneofs() -> bool:
@@ -407,7 +424,8 @@ if __name__ == "__main__":
         test_array_missing_size,
         test_string_missing_size,
         test_string_array_missing_element_size,
-        test_array_max_size_overflow,
+        test_array_max_size_over_255_allowed,
+        test_string_max_size_over_255_allowed,
         test_envelope_zero_oneofs,
         test_envelope_non_message_oneof_fields,
         test_envelope_msgid_discriminator_without_msgid,

--- a/tests/test_no_packed.py
+++ b/tests/test_no_packed.py
@@ -100,6 +100,7 @@ def test_no_packed_flag():
 
         # 5. Encode/decode round-trip with --no_packed succeeds.
         _roundtrip_c(nopacked_dir / "c")
+        _roundtrip_cpp(nopacked_dir / "cpp")
 
         # 6. Wire-size equivalence: for messages that contain only fixed-size
         #    fields (no bounded arrays / variable strings), the variable
@@ -168,6 +169,39 @@ def _roundtrip_c(c_dir: Path) -> None:
     out = c_dir / "_roundtrip.out"
     subprocess.check_call(
         ["gcc", "-std=c99", "-I", str(c_dir), str(src), "-o", str(out)],
+    )
+    subprocess.check_call([str(out)])
+
+
+def _roundtrip_cpp(cpp_dir: Path) -> None:
+    src = cpp_dir / "_roundtrip.cpp"
+    src.write_text(
+        '#include "serialization_test.structframe.hpp"\n'
+        'using structframe::serialization_test::BasicTypesMessage;\n'
+        "int main() {\n"
+        "    BasicTypesMessage m{}, m2{};\n"
+        "    m.small_int = -5; m.medium_int = 1000; m.regular_int = -123456;\n"
+        "    m.large_int = 9000000000LL; m.small_uint = 200;\n"
+        "    m.medium_uint = 50000; m.regular_uint = 4000000000U;\n"
+        "    m.large_uint = 18000000000000ULL;\n"
+        "    m.single_precision = 3.14f; m.double_precision = 2.71828;\n"
+        "    m.flag = true;\n"
+        "    uint8_t buf[512];\n"
+        "    size_t n = m.serialize(buf);\n"
+        "    if (n == 0) return 1;\n"
+        "    m2.deserialize(buf, n);\n"
+        "    if (m.small_int != m2.small_int || m.medium_int != m2.medium_int ||\n"
+        "        m.regular_int != m2.regular_int || m.large_int != m2.large_int ||\n"
+        "        m.small_uint != m2.small_uint || m.medium_uint != m2.medium_uint ||\n"
+        "        m.regular_uint != m2.regular_uint || m.large_uint != m2.large_uint ||\n"
+        "        m.flag != m2.flag) return 2;\n"
+        "    return 0;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    out = cpp_dir / "_roundtrip.out"
+    subprocess.check_call(
+        ["g++", "-std=c++20", "-I", str(cpp_dir), str(src), "-o", str(out)],
     )
     subprocess.check_call([str(out)])
 

--- a/tests/test_validate_flag.py
+++ b/tests/test_validate_flag.py
@@ -68,15 +68,21 @@ def test_validate_success():
 
 def test_validate_no_output_files():
     """--validate must not create any output files in a target directory."""
-    # Run validate on the standard proto (no output path flags).
-    # The important thing is that a directory we control stays empty.
+    # Run validate with an output path pointing to a temp directory.
+    # If --validate is working correctly, no files should be written there.
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
-        code, stdout, stderr = _run_validate(PROTO_FILE)
-        # tmp_path was never referenced as an output dir, so it must be empty.
-        _check(not list(tmp_path.iterdir()),
-               f"--validate should not write files, but found: "
-               f"{list(tmp_path.iterdir())}")
+        code, stdout, stderr = _run_validate(
+            PROTO_FILE,
+            extra_args=["--py_path", str(tmp_path / "py"),
+                        "--c_path", str(tmp_path / "c"),
+                        "--cpp_path", str(tmp_path / "cpp")],
+        )
+        # Even though output paths were provided, --validate must not write files.
+        written = list(tmp_path.rglob("*"))
+        _check(not written,
+               f"--validate should not write files even when output paths are given, "
+               f"but found: {written}")
     _check(code == 0,
            f"--validate on valid proto should succeed, got {code}")
 


### PR DESCRIPTION
This PR resolves follow-up review issues from the previous changeset.

It restores generator validation behavior for `max_size` so values above `255` are accepted (up to `65535`) for 2-byte count/length paths, fixes C++ SDK message ID truncation by preserving `uint16_t` IDs across subscribe/dispatch/send/forwarding paths, and removes mojibake text in C# generator comments/doc strings.

It also adds regression coverage to prevent recurrence:
- Generator validation tests for array/string `max_size > 255` acceptance.
- C++ SDK tests verifying extended message IDs (`>255`) are preserved through `SendRaw` and `FrameMsgInfo` forwarding.